### PR TITLE
feat: 업비트 WebSocket 시세 파이프라인 구현 #7

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 

--- a/backend/src/main/kotlin/com/coinbattle/common/config/AsyncConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/AsyncConfig.kt
@@ -1,0 +1,23 @@
+package com.coinbattle.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+
+    @Bean(name = ["taskExecutor"])
+    fun taskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 4
+        executor.maxPoolSize = 10
+        executor.queueCapacity = 100
+        executor.setThreadNamePrefix("async-task-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/common/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/RedisConfig.kt
@@ -1,0 +1,42 @@
+package com.coinbattle.common.config
+
+import com.coinbattle.domain.market.service.TickerPubSubSubscriber
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
+
+@Configuration
+class RedisConfig(
+    private val tickerPubSubSubscriber: TickerPubSubSubscriber
+) {
+
+    @Bean
+    fun redisMessageListenerContainer(
+        connectionFactory: RedisConnectionFactory
+    ): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(connectionFactory)
+        container.addMessageListener(messageListenerAdapter(), ChannelTopic("ticker:updates"))
+        return container
+    }
+
+    @Bean
+    fun messageListenerAdapter(): MessageListenerAdapter =
+        MessageListenerAdapter(tickerPubSubSubscriber, "onMessage")
+
+    @Bean
+    fun objectMapper(): ObjectMapper =
+        ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+}

--- a/backend/src/main/kotlin/com/coinbattle/common/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/RedisConfig.kt
@@ -1,6 +1,5 @@
 package com.coinbattle.common.config
 
-import com.coinbattle.domain.market.service.TickerPubSubSubscriber
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -9,14 +8,10 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.listener.ChannelTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
 
 @Configuration
-class RedisConfig(
-    private val tickerPubSubSubscriber: TickerPubSubSubscriber
-) {
+class RedisConfig {
 
     @Bean
     fun redisMessageListenerContainer(
@@ -24,13 +19,8 @@ class RedisConfig(
     ): RedisMessageListenerContainer {
         val container = RedisMessageListenerContainer()
         container.setConnectionFactory(connectionFactory)
-        container.addMessageListener(messageListenerAdapter(), ChannelTopic("ticker:updates"))
         return container
     }
-
-    @Bean
-    fun messageListenerAdapter(): MessageListenerAdapter =
-        MessageListenerAdapter(tickerPubSubSubscriber, "onMessage")
 
     @Bean
     fun objectMapper(): ObjectMapper =

--- a/backend/src/main/kotlin/com/coinbattle/common/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/SecurityConfig.kt
@@ -28,8 +28,11 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.requestMatchers(
                     "/api/auth/**",
+                    "/api/market/**",
                     "/oauth2/**",
                     "/login/**",
+                    "/ws-connect/**",
+                    "/topic/**",
                     "/actuator/health"
                 ).permitAll()
                 it.anyRequest().authenticated()

--- a/backend/src/main/kotlin/com/coinbattle/common/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/SecurityConfig.kt
@@ -11,6 +11,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
@@ -21,8 +24,21 @@ class SecurityConfig(
     private val oAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler
 ) {
     @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val config = CorsConfiguration()
+        config.allowedOrigins = listOf("http://localhost:5173")
+        config.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+        config.allowedHeaders = listOf("*")
+        config.allowCredentials = true
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", config)
+        return source
+    }
+
+    @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {

--- a/backend/src/main/kotlin/com/coinbattle/common/config/WebSocketConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/WebSocketConfig.kt
@@ -1,0 +1,23 @@
+package com.coinbattle.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+
+    override fun configureMessageBroker(config: MessageBrokerRegistry) {
+        config.enableSimpleBroker("/topic", "/queue")
+        config.setApplicationDestinationPrefixes("/app")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/ws-connect")
+            .setAllowedOriginPatterns("*")
+            .withSockJS()
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/common/exception/ErrorCode.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/exception/ErrorCode.kt
@@ -5,4 +5,6 @@ enum class ErrorCode(val status: Int, val message: String) {
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN(401, "만료된 토큰입니다"),
     DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다"),
+    TICKER_NOT_FOUND(404, "시세 정보를 찾을 수 없습니다"),
+    MARKET_DATA_UNAVAILABLE(503, "시세 데이터를 사용할 수 없습니다"),
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/client/UpbitWebSocketClient.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/client/UpbitWebSocketClient.kt
@@ -53,6 +53,7 @@ class UpbitWebSocketClient(
             return
         }
 
+        tickerRedisRepository.saveMarkets(markets)
         val subscribePayload = buildSubscribePayload(markets)
         log.info("업비트 WebSocket 연결 시작 — 마켓 {}개", markets.size)
 

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/client/UpbitWebSocketClient.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/client/UpbitWebSocketClient.kt
@@ -1,0 +1,116 @@
+package com.coinbattle.domain.market.client
+
+import com.coinbattle.domain.market.dto.response.ChangeType
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.market.service.TickerPubSubPublisher
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.socket.WebSocketMessage
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient
+import reactor.core.publisher.Mono
+import java.net.URI
+
+@Component
+class UpbitWebSocketClient(
+    private val tickerRedisRepository: TickerRedisRepository,
+    private val tickerPubSubPublisher: TickerPubSubPublisher,
+    private val objectMapper: ObjectMapper
+) : ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val wsClient = ReactorNettyWebSocketClient()
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    override fun run(args: ApplicationArguments) {
+        scope.launch { connectWithBackoff() }
+    }
+
+    private suspend fun connectWithBackoff() {
+        val delays = longArrayOf(1_000, 2_000, 4_000, 8_000, 16_000, 30_000)
+        var attempt = 0
+        while (true) {
+            runCatching { connect() }
+                .onFailure { log.warn("업비트 WebSocket 연결 실패 (attempt={}): {}", attempt + 1, it.message) }
+            val waitMs = delays[minOf(attempt, delays.size - 1)]
+            attempt++
+            delay(waitMs)
+        }
+    }
+
+    private suspend fun connect() {
+        val markets = fetchKrwMarkets()
+        if (markets.isEmpty()) {
+            log.warn("KRW 마켓 목록 조회 실패 — 연결 중단")
+            return
+        }
+
+        val subscribePayload = buildSubscribePayload(markets)
+        log.info("업비트 WebSocket 연결 시작 — 마켓 {}개", markets.size)
+
+        wsClient.execute(URI.create("wss://api.upbit.com/websocket/v1")) { session ->
+            session.send(
+                Mono.just(session.textMessage(subscribePayload))
+            ).thenMany(
+                session.receive()
+                    .map(WebSocketMessage::getPayloadAsText)
+                    .doOnNext { handleMessage(it) }
+                    .doOnError { log.warn("업비트 메시지 수신 오류: {}", it.message) }
+            ).then()
+        }.block()
+    }
+
+    private fun fetchKrwMarkets(): List<String> {
+        return runCatching {
+            val url = "https://api.upbit.com/v1/market/all?isDetails=false"
+            val response = java.net.URL(url).readText()
+            val root = objectMapper.readTree(response)
+            root.mapNotNull { node ->
+                node["market"]?.asText()?.takeIf { it.startsWith("KRW-") }
+            }
+        }.getOrElse {
+            log.error("업비트 마켓 목록 조회 실패: {}", it.message)
+            emptyList()
+        }
+    }
+
+    private fun buildSubscribePayload(markets: List<String>): String {
+        val codesJson = markets.joinToString(",") { "\"$it\"" }
+        return """[{"ticket":"coinbattle-server"},{"type":"ticker","codes":[$codesJson]}]"""
+    }
+
+    private fun handleMessage(raw: String) {
+        runCatching {
+            val node = objectMapper.readTree(raw)
+            val ticker = node.toTickerResponse() ?: return
+            tickerRedisRepository.save(ticker)
+            tickerPubSubPublisher.publish(ticker)
+        }.onFailure { log.debug("업비트 메시지 파싱 실패: {}", it.message) }
+    }
+
+    private fun JsonNode.toTickerResponse(): TickerResponse? {
+        val market = this["code"]?.asText() ?: return null
+        val changeRaw = this["change"]?.asText() ?: "EVEN"
+        val change = runCatching { ChangeType.valueOf(changeRaw) }.getOrDefault(ChangeType.EVEN)
+        return TickerResponse(
+            market = market,
+            tradePrice = this["trade_price"]?.asDouble() ?: return null,
+            changeRate = this["signed_change_rate"]?.asDouble() ?: return null,
+            changePrice = this["signed_change_price"]?.asDouble() ?: return null,
+            change = change,
+            accTradeVolume24h = this["acc_trade_volume_24h"]?.asDouble() ?: return null,
+            accTradePrice24h = this["acc_trade_price_24h"]?.asDouble() ?: return null,
+            highPrice = this["high_price"]?.asDouble() ?: return null,
+            lowPrice = this["low_price"]?.asDouble() ?: return null,
+            timestamp = this["timestamp"]?.asLong()
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/controller/MarketController.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/controller/MarketController.kt
@@ -1,0 +1,33 @@
+package com.coinbattle.domain.market.controller
+
+import com.coinbattle.common.dto.ApiResponse
+import com.coinbattle.domain.market.dto.response.TickerListResponse
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.coinbattle.domain.market.service.MarketService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/market")
+class MarketController(
+    private val marketService: MarketService
+) {
+
+    @GetMapping("/tickers")
+    fun getTickers(
+        @RequestParam(required = false) markets: String?
+    ): ResponseEntity<ApiResponse<TickerListResponse>> {
+        val marketList = markets?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+        return ResponseEntity.ok(ApiResponse.ok(marketService.getTickers(marketList)))
+    }
+
+    @GetMapping("/tickers/{market}")
+    fun getTicker(
+        @PathVariable market: String
+    ): ResponseEntity<ApiResponse<TickerResponse>> =
+        ResponseEntity.ok(ApiResponse.ok(marketService.getTicker(market)))
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/dto/response/ChangeType.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/dto/response/ChangeType.kt
@@ -1,0 +1,5 @@
+package com.coinbattle.domain.market.dto.response
+
+enum class ChangeType {
+    RISE, FALL, EVEN
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/dto/response/TickerListResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/dto/response/TickerListResponse.kt
@@ -1,0 +1,5 @@
+package com.coinbattle.domain.market.dto.response
+
+data class TickerListResponse(
+    val tickers: List<TickerResponse>
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/dto/response/TickerResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/dto/response/TickerResponse.kt
@@ -1,0 +1,19 @@
+package com.coinbattle.domain.market.dto.response
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import java.time.Instant
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class TickerResponse(
+    val market: String,
+    val tradePrice: Double,
+    val changeRate: Double,
+    val changePrice: Double,
+    val change: ChangeType,
+    val accTradeVolume24h: Double,
+    val accTradePrice24h: Double,
+    val highPrice: Double,
+    val lowPrice: Double,
+    val cachedAt: Instant? = null,
+    val timestamp: Long? = null
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/repository/TickerRedisRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/repository/TickerRedisRepository.kt
@@ -1,0 +1,81 @@
+package com.coinbattle.domain.market.repository
+
+import com.coinbattle.domain.market.dto.response.ChangeType
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import org.springframework.data.redis.core.ScanOptions
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
+import java.time.Instant
+
+@Repository
+class TickerRedisRepository(
+    private val stringRedisTemplate: StringRedisTemplate
+) {
+    private val ttl = Duration.ofSeconds(3)
+
+    fun save(ticker: TickerResponse) {
+        val key = "ticker:${ticker.market}"
+        val ops = stringRedisTemplate.opsForHash<String, String>()
+        val fields = mapOf(
+            "market" to ticker.market,
+            "tradePrice" to ticker.tradePrice.toString(),
+            "changeRate" to ticker.changeRate.toString(),
+            "changePrice" to ticker.changePrice.toString(),
+            "change" to ticker.change.name,
+            "accTradeVolume24h" to ticker.accTradeVolume24h.toString(),
+            "accTradePrice24h" to ticker.accTradePrice24h.toString(),
+            "highPrice" to ticker.highPrice.toString(),
+            "lowPrice" to ticker.lowPrice.toString(),
+            "cachedAt" to Instant.now().toString(),
+            "timestamp" to (ticker.timestamp?.toString() ?: "")
+        )
+        ops.putAll(key, fields)
+        stringRedisTemplate.expire(key, ttl)
+    }
+
+    fun findByMarket(market: String): TickerResponse? {
+        val key = "ticker:$market"
+        val fields = stringRedisTemplate.opsForHash<String, String>().entries(key)
+        if (fields.isEmpty()) return null
+        return fields.toTickerResponse()
+    }
+
+    fun findAll(): List<TickerResponse> {
+        val scanOptions = ScanOptions.scanOptions()
+            .match("ticker:*")
+            .count(200)
+            .build()
+        val keys = stringRedisTemplate.execute { connection ->
+            connection.keyCommands().scan(scanOptions).use { cursor ->
+                cursor.asSequence().map { String(it) }.toList()
+            }
+        } ?: emptyList()
+
+        return keys.mapNotNull { key ->
+            stringRedisTemplate.opsForHash<String, String>().entries(key)
+                .takeIf { it.isNotEmpty() }
+                ?.toTickerResponse()
+        }
+    }
+
+    fun findByMarkets(markets: List<String>): List<TickerResponse> =
+        markets.mapNotNull { findByMarket(it) }
+
+    private fun Map<String, String>.toTickerResponse(): TickerResponse? {
+        val market = this["market"] ?: return null
+        return TickerResponse(
+            market = market,
+            tradePrice = this["tradePrice"]?.toDoubleOrNull() ?: return null,
+            changeRate = this["changeRate"]?.toDoubleOrNull() ?: return null,
+            changePrice = this["changePrice"]?.toDoubleOrNull() ?: return null,
+            change = this["change"]?.let { runCatching { ChangeType.valueOf(it) }.getOrNull() } ?: return null,
+            accTradeVolume24h = this["accTradeVolume24h"]?.toDoubleOrNull() ?: return null,
+            accTradePrice24h = this["accTradePrice24h"]?.toDoubleOrNull() ?: return null,
+            highPrice = this["highPrice"]?.toDoubleOrNull() ?: return null,
+            lowPrice = this["lowPrice"]?.toDoubleOrNull() ?: return null,
+            cachedAt = this["cachedAt"]?.let { runCatching { Instant.parse(it) }.getOrNull() },
+            timestamp = this["timestamp"]?.toLongOrNull()
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/repository/TickerRedisRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/repository/TickerRedisRepository.kt
@@ -11,7 +11,7 @@ import java.time.Instant
 class TickerRedisRepository(
     private val stringRedisTemplate: StringRedisTemplate
 ) {
-    private val ttl = Duration.ofSeconds(3)
+    private val ttl = Duration.ofSeconds(30)
     private val MARKETS_KEY = "ticker:markets"
 
     fun save(ticker: TickerResponse) {

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/repository/TickerRedisRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/repository/TickerRedisRepository.kt
@@ -2,7 +2,6 @@ package com.coinbattle.domain.market.repository
 
 import com.coinbattle.domain.market.dto.response.ChangeType
 import com.coinbattle.domain.market.dto.response.TickerResponse
-import org.springframework.data.redis.core.ScanOptions
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Repository
 import java.time.Duration
@@ -13,6 +12,7 @@ class TickerRedisRepository(
     private val stringRedisTemplate: StringRedisTemplate
 ) {
     private val ttl = Duration.ofSeconds(3)
+    private val MARKETS_KEY = "ticker:markets"
 
     fun save(ticker: TickerResponse) {
         val key = "ticker:${ticker.market}"
@@ -41,22 +41,13 @@ class TickerRedisRepository(
         return fields.toTickerResponse()
     }
 
-    fun findAll(): List<TickerResponse> {
-        val scanOptions = ScanOptions.scanOptions()
-            .match("ticker:*")
-            .count(200)
-            .build()
-        val keys = stringRedisTemplate.execute { connection ->
-            connection.keyCommands().scan(scanOptions).use { cursor ->
-                cursor.asSequence().map { String(it) }.toList()
-            }
-        } ?: emptyList()
+    fun saveMarkets(markets: List<String>) {
+        stringRedisTemplate.opsForSet().add(MARKETS_KEY, *markets.toTypedArray())
+    }
 
-        return keys.mapNotNull { key ->
-            stringRedisTemplate.opsForHash<String, String>().entries(key)
-                .takeIf { it.isNotEmpty() }
-                ?.toTickerResponse()
-        }
+    fun findAll(): List<TickerResponse> {
+        val markets = stringRedisTemplate.opsForSet().members(MARKETS_KEY) ?: return emptyList()
+        return markets.mapNotNull { findByMarket(it) }
     }
 
     fun findByMarkets(markets: List<String>): List<TickerResponse> =

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/service/MarketService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/service/MarketService.kt
@@ -1,0 +1,26 @@
+package com.coinbattle.domain.market.service
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.domain.market.dto.response.TickerListResponse
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import org.springframework.stereotype.Service
+
+@Service
+class MarketService(
+    private val tickerRedisRepository: TickerRedisRepository
+) {
+    fun getTickers(markets: List<String>?): TickerListResponse {
+        val tickers = if (markets.isNullOrEmpty()) {
+            tickerRedisRepository.findAll()
+        } else {
+            tickerRedisRepository.findByMarkets(markets)
+        }
+        return TickerListResponse(tickers)
+    }
+
+    fun getTicker(market: String): TickerResponse =
+        tickerRedisRepository.findByMarket(market)
+            ?: throw CoinBattleException(ErrorCode.TICKER_NOT_FOUND)
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/service/TickerPubSubPublisher.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/service/TickerPubSubPublisher.kt
@@ -1,0 +1,17 @@
+package com.coinbattle.domain.market.service
+
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class TickerPubSubPublisher(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper
+) {
+    fun publish(ticker: TickerResponse) {
+        val json = objectMapper.writeValueAsString(ticker)
+        stringRedisTemplate.convertAndSend("ticker:updates", json)
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/service/TickerPubSubSubscriber.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/service/TickerPubSubSubscriber.kt
@@ -1,0 +1,24 @@
+package com.coinbattle.domain.market.service
+
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class TickerPubSubSubscriber(
+    private val simpMessagingTemplate: SimpMessagingTemplate,
+    private val objectMapper: ObjectMapper
+) : MessageListener {
+
+    fun onMessage(message: String) {
+        val ticker = objectMapper.readValue(message, TickerResponse::class.java)
+        simpMessagingTemplate.convertAndSend("/topic/ticker/${ticker.market}", ticker)
+    }
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        onMessage(String(message.body))
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/service/TickerPubSubSubscriber.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/service/TickerPubSubSubscriber.kt
@@ -2,16 +2,25 @@ package com.coinbattle.domain.market.service
 
 import com.coinbattle.domain.market.dto.response.TickerResponse
 import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.annotation.PostConstruct
 import org.springframework.data.redis.connection.Message
 import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 
 @Service
 class TickerPubSubSubscriber(
     private val simpMessagingTemplate: SimpMessagingTemplate,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val redisMessageListenerContainer: RedisMessageListenerContainer
 ) : MessageListener {
+
+    @PostConstruct
+    fun registerListener() {
+        redisMessageListenerContainer.addMessageListener(this, ChannelTopic("ticker:updates"))
+    }
 
     fun onMessage(message: String) {
         val ticker = objectMapper.readValue(message, TickerResponse::class.java)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@stomp/stompjs": "^7.3.0",
         "@tanstack/react-query": "^5.100.5",
         "axios": "^1.15.2",
+        "motion": "^12.38.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2",
@@ -2425,6 +2426,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3176,6 +3204,47 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4081,9 +4150,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.100.5",
     "axios": "^1.15.2",
+    "motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,14 @@ import { Routes, Route } from 'react-router-dom';
 import { AuthGuard } from './components/AuthGuard';
 import { LoginPage } from './pages/LoginPage';
 import { OAuth2Callback } from './pages/OAuth2Callback';
+import { MarketListPage } from './pages/MarketListPage';
 
 function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/oauth2/callback" element={<OAuth2Callback />} />
-      <Route path="/" element={<AuthGuard><div>Home</div></AuthGuard>} />
+      <Route path="/" element={<AuthGuard><MarketListPage /></AuthGuard>} />
       <Route path="/coin/:ticker" element={<AuthGuard><div>CoinDetail</div></AuthGuard>} />
       <Route path="/battle" element={<AuthGuard><div>Battle</div></AuthGuard>} />
       <Route path="/ranking" element={<AuthGuard><div>Ranking</div></AuthGuard>} />

--- a/frontend/src/hooks/useMarketTickers.ts
+++ b/frontend/src/hooks/useMarketTickers.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { useTickerStore, type Ticker } from '../store/tickerStore';
+
+interface TickerListApiResponse {
+  data: {
+    tickers: Ticker[];
+  };
+}
+
+export function useMarketTickers() {
+  const setTickers = useTickerStore((s) => s.setTickers);
+
+  return useQuery({
+    queryKey: ['market', 'tickers'],
+    queryFn: async () => {
+      const response = await api.get<TickerListApiResponse>('/api/market/tickers');
+      const tickers = response.data.data.tickers;
+      setTickers(tickers);
+      return tickers;
+    },
+    staleTime: 0,
+    gcTime: 30_000,
+  });
+}

--- a/frontend/src/hooks/useTickerSubscription.ts
+++ b/frontend/src/hooks/useTickerSubscription.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import type { StompSubscription } from '@stomp/stompjs';
+import { connectStomp, getStompClient } from '../lib/stomp';
+import { useTickerStore, type Ticker } from '../store/tickerStore';
+
+export function useTickerSubscription(markets: string[]) {
+  const setTicker = useTickerStore((s) => s.setTicker);
+  const subscriptionsRef = useRef<StompSubscription[]>([]);
+  const marketsKey = markets.join(',');
+
+  useEffect(() => {
+    if (markets.length === 0) return;
+    let mounted = true;
+
+    connectStomp().then(() => {
+      if (!mounted) return;
+      const client = getStompClient();
+      subscriptionsRef.current = markets.map((market) =>
+        client.subscribe(`/topic/ticker/${market}`, (message) => {
+          try {
+            const ticker: Ticker = JSON.parse(message.body);
+            setTicker(ticker);
+          } catch {
+            // ignore malformed frames
+          }
+        })
+      );
+    });
+
+    return () => {
+      mounted = false;
+      subscriptionsRef.current.forEach((sub) => sub.unsubscribe());
+      subscriptionsRef.current = [];
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [marketsKey]);
+}

--- a/frontend/src/pages/MarketListPage.tsx
+++ b/frontend/src/pages/MarketListPage.tsx
@@ -91,8 +91,11 @@ function SkeletonRow() {
   );
 }
 
+const PAGE_SIZE = 20;
+
 export function MarketListPage() {
   const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
   const { isLoading, isError, refetch } = useMarketTickers();
   const tickers = useTickerStore((s) => s.tickers);
   const markets = Array.from(tickers.keys());
@@ -103,6 +106,13 @@ export function MarketListPage() {
     getCoinSymbol(t.market).toLowerCase().includes(search.toLowerCase())
   );
   const sorted = [...filtered].sort((a, b) => b.accTradePrice24h - a.accTradePrice24h);
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const paginated = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const handleSearch = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
 
   return (
     <div className="min-h-screen bg-[#0C0C0D] text-white">
@@ -114,6 +124,9 @@ export function MarketListPage() {
           <span className="text-xs bg-[#2DD4BF]/20 text-[#2DD4BF] px-2 py-0.5 rounded-full font-medium">
             실시간
           </span>
+          {!isLoading && sorted.length > 0 && (
+            <span className="text-xs text-zinc-600 ml-auto">{sorted.length}개</span>
+          )}
         </div>
       </header>
 
@@ -123,7 +136,7 @@ export function MarketListPage() {
             type="text"
             placeholder="코인 검색..."
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => handleSearch(e.target.value)}
             className="w-full bg-zinc-900 border border-zinc-800 rounded-xl px-4 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-zinc-600 transition-colors"
           />
         </div>
@@ -149,7 +162,7 @@ export function MarketListPage() {
 
         {isLoading && (
           <div>
-            {Array.from({ length: 20 }).map((_, i) => (
+            {Array.from({ length: PAGE_SIZE }).map((_, i) => (
               <SkeletonRow key={i} />
             ))}
           </div>
@@ -157,7 +170,7 @@ export function MarketListPage() {
 
         {!isLoading && !isError && (
           <AnimatePresence>
-            {sorted.map((ticker) => (
+            {paginated.map((ticker) => (
               <TickerRow key={ticker.market} ticker={ticker} />
             ))}
           </AnimatePresence>
@@ -167,6 +180,51 @@ export function MarketListPage() {
           <p className="text-center py-20 text-zinc-600 text-sm">
             "{search}"에 대한 결과가 없습니다
           </p>
+        )}
+
+        {!isLoading && !isError && totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 px-4 py-4 border-t border-zinc-800">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="px-3 py-1.5 text-xs rounded-lg bg-zinc-800 text-zinc-400 hover:bg-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              이전
+            </button>
+            <div className="flex items-center gap-1">
+              {Array.from({ length: totalPages }, (_, i) => i + 1)
+                .filter((p) => p === 1 || p === totalPages || Math.abs(p - page) <= 2)
+                .reduce<(number | '...')[]>((acc, p, idx, arr) => {
+                  if (idx > 0 && (arr[idx - 1] as number) + 1 < p) acc.push('...');
+                  acc.push(p);
+                  return acc;
+                }, [])
+                .map((p, i) =>
+                  p === '...' ? (
+                    <span key={`ellipsis-${i}`} className="px-1 text-xs text-zinc-600">…</span>
+                  ) : (
+                    <button
+                      key={p}
+                      onClick={() => setPage(p as number)}
+                      className={`w-7 h-7 text-xs rounded-lg transition-colors ${
+                        page === p
+                          ? 'bg-orange-500 text-white font-semibold'
+                          : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700'
+                      }`}
+                    >
+                      {p}
+                    </button>
+                  )
+                )}
+            </div>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="px-3 py-1.5 text-xs rounded-lg bg-zinc-800 text-zinc-400 hover:bg-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              다음
+            </button>
+          </div>
         )}
       </main>
     </div>

--- a/frontend/src/pages/MarketListPage.tsx
+++ b/frontend/src/pages/MarketListPage.tsx
@@ -1,0 +1,174 @@
+import { useState, useRef, useEffect } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { useMarketTickers } from '../hooks/useMarketTickers';
+import { useTickerSubscription } from '../hooks/useTickerSubscription';
+import { useTickerStore, type Ticker } from '../store/tickerStore';
+
+function formatPrice(price: number): string {
+  return price.toLocaleString('ko-KR');
+}
+
+function formatRate(rate: number): string {
+  const sign = rate > 0 ? '+' : '';
+  return `${sign}${(rate * 100).toFixed(2)}%`;
+}
+
+function formatVolume(volume: number): string {
+  if (volume >= 1_000_000_000_000) return `${(volume / 1_000_000_000_000).toFixed(0)}조`;
+  if (volume >= 100_000_000) return `${(volume / 100_000_000).toFixed(0)}억`;
+  if (volume >= 10_000) return `${(volume / 10_000).toFixed(0)}만`;
+  return volume.toLocaleString('ko-KR');
+}
+
+function getCoinSymbol(market: string): string {
+  return market.replace('KRW-', '');
+}
+
+function TickerRow({ ticker }: { ticker: Ticker }) {
+  const prevPriceRef = useRef<number>(ticker.tradePrice);
+  const [flash, setFlash] = useState<'up' | 'down' | null>(null);
+
+  useEffect(() => {
+    if (ticker.tradePrice !== prevPriceRef.current) {
+      setFlash(ticker.tradePrice > prevPriceRef.current ? 'up' : 'down');
+      prevPriceRef.current = ticker.tradePrice;
+      const id = setTimeout(() => setFlash(null), 500);
+      return () => clearTimeout(id);
+    }
+  }, [ticker.tradePrice]);
+
+  const changeColor =
+    ticker.change === 'RISE'
+      ? 'text-[#2DD4BF]'
+      : ticker.change === 'FALL'
+      ? 'text-red-500'
+      : 'text-zinc-400';
+
+  const flashBg =
+    flash === 'up'
+      ? 'bg-[#2DD4BF]/10'
+      : flash === 'down'
+      ? 'bg-red-500/10'
+      : '';
+
+  return (
+    <motion.div
+      className={`flex items-center px-4 py-3 border-b border-zinc-800 transition-colors duration-300 ${flashBg} hover:bg-zinc-800/50 cursor-pointer`}
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15 }}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-white text-sm">{getCoinSymbol(ticker.market)}</span>
+          <span className="text-xs text-zinc-600">{ticker.market}</span>
+        </div>
+      </div>
+      <div className={`text-right w-36 font-mono font-semibold text-sm ${changeColor}`}>
+        ₩{formatPrice(ticker.tradePrice)}
+      </div>
+      <div className={`text-right w-24 font-mono text-sm ${changeColor}`}>
+        {formatRate(ticker.changeRate)}
+      </div>
+      <div className="text-right w-28 text-zinc-500 font-mono text-xs hidden sm:block">
+        {formatVolume(ticker.accTradePrice24h)}
+      </div>
+    </motion.div>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <div className="flex items-center px-4 py-3 border-b border-zinc-800 animate-pulse">
+      <div className="flex-1 space-y-1">
+        <div className="h-4 bg-zinc-800 rounded w-16" />
+        <div className="h-3 bg-zinc-900 rounded w-24" />
+      </div>
+      <div className="w-36 h-4 bg-zinc-800 rounded" />
+      <div className="w-24 h-4 bg-zinc-800 rounded ml-4" />
+      <div className="w-28 h-4 bg-zinc-800 rounded ml-4 hidden sm:block" />
+    </div>
+  );
+}
+
+export function MarketListPage() {
+  const [search, setSearch] = useState('');
+  const { isLoading, isError, refetch } = useMarketTickers();
+  const tickers = useTickerStore((s) => s.tickers);
+  const markets = Array.from(tickers.keys());
+
+  useTickerSubscription(markets);
+
+  const filtered = Array.from(tickers.values()).filter((t) =>
+    getCoinSymbol(t.market).toLowerCase().includes(search.toLowerCase())
+  );
+  const sorted = [...filtered].sort((a, b) => b.accTradePrice24h - a.accTradePrice24h);
+
+  return (
+    <div className="min-h-screen bg-[#0C0C0D] text-white">
+      <header className="sticky top-0 z-10 bg-[#0C0C0D]/95 backdrop-blur border-b border-zinc-800 px-4 py-3">
+        <div className="max-w-2xl mx-auto flex items-center gap-3">
+          <h1 className="text-lg font-extrabold bg-gradient-to-r from-orange-400 to-yellow-400 bg-clip-text text-transparent">
+            CoinBattle
+          </h1>
+          <span className="text-xs bg-[#2DD4BF]/20 text-[#2DD4BF] px-2 py-0.5 rounded-full font-medium">
+            실시간
+          </span>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto">
+        <div className="px-4 py-3">
+          <input
+            type="text"
+            placeholder="코인 검색..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-800 rounded-xl px-4 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-zinc-600 transition-colors"
+          />
+        </div>
+
+        <div className="flex items-center px-4 py-2 text-xs text-zinc-600 border-b border-zinc-800">
+          <div className="flex-1">코인</div>
+          <div className="w-36 text-right">현재가</div>
+          <div className="w-24 text-right">등락률</div>
+          <div className="w-28 text-right hidden sm:block">거래대금</div>
+        </div>
+
+        {isError && (
+          <div className="flex flex-col items-center justify-center py-20 gap-4">
+            <p className="text-zinc-500 text-sm">시세를 불러올 수 없습니다</p>
+            <button
+              onClick={() => refetch()}
+              className="px-5 py-2 bg-orange-500 hover:bg-orange-400 active:bg-orange-600 text-white text-sm font-semibold rounded-xl transition-colors"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {isLoading && (
+          <div>
+            {Array.from({ length: 20 }).map((_, i) => (
+              <SkeletonRow key={i} />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !isError && (
+          <AnimatePresence>
+            {sorted.map((ticker) => (
+              <TickerRow key={ticker.market} ticker={ticker} />
+            ))}
+          </AnimatePresence>
+        )}
+
+        {!isLoading && !isError && sorted.length === 0 && search && (
+          <p className="text-center py-20 text-zinc-600 text-sm">
+            "{search}"에 대한 결과가 없습니다
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/store/tickerStore.ts
+++ b/frontend/src/store/tickerStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+
+export interface Ticker {
+  market: string;
+  tradePrice: number;
+  changeRate: number;
+  changePrice: number;
+  change: 'RISE' | 'FALL' | 'EVEN';
+  accTradeVolume24h: number;
+  accTradePrice24h: number;
+  highPrice?: number;
+  lowPrice?: number;
+  timestamp?: number;
+}
+
+interface TickerState {
+  tickers: Map<string, Ticker>;
+  setTicker: (ticker: Ticker) => void;
+  setTickers: (tickers: Ticker[]) => void;
+  clearTickers: () => void;
+}
+
+export const useTickerStore = create<TickerState>((set) => ({
+  tickers: new Map(),
+  setTicker: (ticker) =>
+    set((state) => {
+      const next = new Map(state.tickers);
+      next.set(ticker.market, ticker);
+      return { tickers: next };
+    }),
+  setTickers: (tickers) =>
+    set(() => {
+      const map = new Map<string, Ticker>();
+      tickers.forEach((t) => map.set(t.market, t));
+      return { tickers: map };
+    }),
+  clearTickers: () => set({ tickers: new Map() }),
+}));


### PR DESCRIPTION
## 개요

업비트 WebSocket으로 KRW 마켓 200개+ 실시간 시세를 수신하고, Redis Hash 캐싱 → Redis Pub/Sub → STOMP 브로드캐스트 파이프라인을 구현했습니다. 프론트엔드 시세 목록 홈 화면도 함께 포함합니다.

## 변경 내용

### 백엔드
- `UpbitWebSocketClient.kt` — 업비트 WebSocket 연결, KRW 마켓 실시간 티커 수신, 지수 백오프 재연결
- `TickerRedisRepository.kt` — Redis Hash 캐싱 (`ticker:{market}`, TTL 30초) + `ticker:markets` SET으로 전체 마켓 목록 영구 관리
- `TickerPubSubPublisher.kt` / `TickerPubSubSubscriber.kt` — Redis Pub/Sub → STOMP `/topic/ticker/{market}` 브로드캐스트
- `MarketController.kt` — `GET /api/market/tickers`, `GET /api/market/tickers/{market}`
- `WebSocketConfig.kt` — STOMP 엔드포인트 설정 (`/ws-connect`, `/topic`, `/app`)
- `SecurityConfig.kt` — CORS 허용 (localhost:5173), `/api/market/**`, `/ws-connect/**` permitAll
- `RedisConfig.kt` — `RedisMessageListenerContainer` Bean 등록 (순환 참조 방지 구조)

### 프론트엔드
- `tickerStore.ts` — 실시간 시세 Zustand 스토어 (코인별 Map 관리)
- `useMarketTickers.ts` — TanStack Query로 초기 스냅샷 로드
- `useTickerSubscription.ts` — STOMP `/topic/ticker/{market}` 구독
- `MarketListPage.tsx` — 가격 flash 애니메이션, 검색, 페이지네이션(20개/페이지), 다크 테마

## 관련 이슈

Close #7