### PR TITLE
[feat]: PVP 배틀 시스템 기본 구조 및 매칭 #14

### DIFF
--- a/backend/src/main/kotlin/com/coinbattle/common/exception/ErrorCode.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/exception/ErrorCode.kt
@@ -20,4 +20,13 @@ enum class ErrorCode(val status: Int, val message: String) {
     POSITION_ALREADY_CLOSED(409, "이미 청산된 포지션입니다"),
     INVALID_CANDLE_UNIT(400, "유효하지 않은 분봉 단위입니다. 허용값: 1, 3, 5, 10, 15, 30, 60, 240"),
     CANDLE_DATA_UNAVAILABLE(503, "캔들 데이터를 가져올 수 없습니다"),
+    INVALID_SEED_MONEY(400, "시드머니는 10,000원 이상 10,000,000원 이하여야 합니다"),
+    INVALID_DURATION(400, "배틀 시간은 10, 30, 60분 중 하나여야 합니다"),
+    INVALID_MAX_PARTICIPANTS(400, "최대 참가자 수는 2, 3, 5명 중 하나여야 합니다"),
+    ALREADY_IN_BATTLE(409, "이미 진행 중인 배틀이 있습니다"),
+    BATTLE_NOT_FOUND(404, "배틀을 찾을 수 없습니다"),
+    BATTLE_ALREADY_STARTED(409, "이미 시작된 배틀입니다"),
+    BATTLE_FULL(409, "배틀 참가자가 가득 찼습니다"),
+    BATTLE_LOCK_TIMEOUT(423, "배틀 처리 중입니다. 잠시 후 다시 시도해주세요"),
+    NOT_IN_MATCH_QUEUE(404, "매칭 큐에 등록되지 않은 상태입니다"),
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/controller/BattleController.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/controller/BattleController.kt
@@ -1,0 +1,86 @@
+package com.coinbattle.domain.battle.controller
+
+import com.coinbattle.common.dto.ApiResponse
+import com.coinbattle.domain.battle.dto.request.CreateBattleRequest
+import com.coinbattle.domain.battle.dto.request.MatchBattleRequest
+import com.coinbattle.domain.battle.dto.response.BattleListResponse
+import com.coinbattle.domain.battle.dto.response.BattleResponse
+import com.coinbattle.domain.battle.dto.response.JoinBattleResponse
+import com.coinbattle.domain.battle.dto.response.MatchQueueResponse
+import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.service.BattleMatchingService
+import com.coinbattle.domain.battle.service.BattleService
+import com.coinbattle.domain.user.entity.CoinBattlePrincipal
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/battles")
+class BattleController(
+    private val battleService: BattleService,
+    private val battleMatchingService: BattleMatchingService
+) {
+    @PostMapping
+    fun createBattle(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal,
+        @Valid @RequestBody request: CreateBattleRequest
+    ): ResponseEntity<ApiResponse<BattleResponse>> {
+        val result = battleService.createBattle(principal.user.id, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result))
+    }
+
+    @PostMapping("/{battleId}/join")
+    fun joinBattle(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal,
+        @PathVariable battleId: UUID
+    ): ResponseEntity<ApiResponse<JoinBattleResponse>> {
+        val result = battleService.joinBattle(principal.user.id, battleId)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+
+    @GetMapping("/{battleId}")
+    fun getBattle(
+        @PathVariable battleId: UUID
+    ): ResponseEntity<ApiResponse<BattleResponse>> {
+        val result = battleService.getBattle(battleId)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+
+    @GetMapping
+    fun getBattleList(
+        @RequestParam(defaultValue = "WAITING") status: BattleStatus,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<ApiResponse<BattleListResponse>> {
+        val result = battleService.getBattleList(status, page, size)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+
+    @PostMapping("/match")
+    fun joinMatchQueue(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal,
+        @Valid @RequestBody request: MatchBattleRequest
+    ): ResponseEntity<ApiResponse<MatchQueueResponse>> {
+        val result = battleMatchingService.joinMatchQueue(principal.user.id, request)
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.ok(result))
+    }
+
+    @DeleteMapping("/match")
+    fun leaveMatchQueue(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal
+    ): ResponseEntity<Void> {
+        battleMatchingService.leaveMatchQueue(principal.user.id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/request/CreateBattleRequest.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/request/CreateBattleRequest.kt
@@ -1,0 +1,12 @@
+package com.coinbattle.domain.battle.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+
+data class CreateBattleRequest(
+    @field:Min(1) @field:Max(10) val leverage: Int,
+    @field:Min(10000) @field:Max(10000000) val seedMoney: Long,
+    @field:NotNull val duration: Int,
+    @field:NotNull val maxParticipants: Int
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/request/MatchBattleRequest.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/request/MatchBattleRequest.kt
@@ -1,0 +1,12 @@
+package com.coinbattle.domain.battle.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+
+data class MatchBattleRequest(
+    @field:Min(1) @field:Max(10) val leverage: Int,
+    @field:Min(10000) @field:Max(10000000) val seedMoney: Long,
+    @field:NotNull val duration: Int,
+    @field:NotNull val maxParticipants: Int
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleListResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleListResponse.kt
@@ -1,0 +1,36 @@
+package com.coinbattle.domain.battle.dto.response
+
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.enum.BattleStatus
+
+data class BattleListResponse(
+    val content: List<BattleSummary>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val page: Int,
+    val size: Int
+)
+
+data class BattleSummary(
+    val battleId: String,
+    val status: BattleStatus,
+    val leverage: Int,
+    val seedMoney: Long,
+    val duration: Int,
+    val maxParticipants: Int,
+    val currentParticipants: Int,
+    val createdAt: String
+) {
+    companion object {
+        fun from(battle: Battle) = BattleSummary(
+            battleId = battle.battleId.toString(),
+            status = battle.status,
+            leverage = battle.leverage,
+            seedMoney = battle.seedMoney,
+            duration = battle.duration,
+            maxParticipants = battle.maxParticipants,
+            currentParticipants = battle.currentParticipants,
+            createdAt = battle.createdAt.toString()
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleResponse.kt
@@ -1,0 +1,47 @@
+package com.coinbattle.domain.battle.dto.response
+
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.enum.BattleStatus
+import java.math.BigDecimal
+
+data class BattleResponse(
+    val battleId: String,
+    val status: BattleStatus,
+    val hostUserId: Long,
+    val leverage: Int,
+    val seedMoney: Long,
+    val duration: Int,
+    val maxParticipants: Int,
+    val currentParticipants: Int,
+    val startTime: String?,
+    val endTime: String?,
+    val participants: List<ParticipantInfo>?,
+    val winnerId: Long?,
+    val createdAt: String
+) {
+    companion object {
+        fun from(battle: Battle, participants: List<ParticipantInfo>? = null) = BattleResponse(
+            battleId = battle.battleId.toString(),
+            status = battle.status,
+            hostUserId = battle.hostUserId,
+            leverage = battle.leverage,
+            seedMoney = battle.seedMoney,
+            duration = battle.duration,
+            maxParticipants = battle.maxParticipants,
+            currentParticipants = battle.currentParticipants,
+            startTime = battle.startTime?.toString(),
+            endTime = battle.endTime?.toString(),
+            participants = participants,
+            winnerId = battle.winnerId,
+            createdAt = battle.createdAt.toString()
+        )
+    }
+}
+
+data class ParticipantInfo(
+    val userId: Long,
+    val nickname: String,
+    val seedPriceSnapshot: Map<String, BigDecimal>?,
+    val currentValuation: Long?,
+    val returnRate: Double?
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleWebSocketMessage.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleWebSocketMessage.kt
@@ -1,0 +1,43 @@
+package com.coinbattle.domain.battle.dto.response
+
+import java.time.Instant
+
+data class BattleWebSocketMessage(
+    val type: BattleMessageType,
+    val battleId: String,
+    val data: BattleMessageData,
+    val timestamp: String = Instant.now().toString()
+)
+
+enum class BattleMessageType {
+    PARTICIPANT_JOINED,
+    BATTLE_STARTED,
+    RANK_UPDATE,
+    BATTLE_FINISHED
+}
+
+data class BattleMessageData(
+    val userId: Long? = null,
+    val currentParticipants: Int? = null,
+    val rankings: List<BattleRankEntry>? = null,
+    val winnerId: Long? = null
+)
+
+data class BattleRankEntry(
+    val rank: Int,
+    val userId: Long,
+    val nickname: String,
+    val returnRate: Double,
+    val currentValuation: Long
+)
+
+data class MatchFoundMessage(
+    val battleId: String,
+    val status: String,
+    val participants: List<MatchParticipant>
+)
+
+data class MatchParticipant(
+    val userId: Long,
+    val nickname: String
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/JoinBattleResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/JoinBattleResponse.kt
@@ -1,0 +1,22 @@
+package com.coinbattle.domain.battle.dto.response
+
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.enum.BattleStatus
+
+data class JoinBattleResponse(
+    val battleId: String,
+    val status: BattleStatus,
+    val currentParticipants: Int,
+    val maxParticipants: Int,
+    val startTime: String?
+) {
+    companion object {
+        fun from(battle: Battle) = JoinBattleResponse(
+            battleId = battle.battleId.toString(),
+            status = battle.status,
+            currentParticipants = battle.currentParticipants,
+            maxParticipants = battle.maxParticipants,
+            startTime = battle.startTime?.toString()
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/MatchQueueResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/MatchQueueResponse.kt
@@ -1,0 +1,6 @@
+package com.coinbattle.domain.battle.dto.response
+
+data class MatchQueueResponse(
+    val queueKey: String,
+    val estimatedWaitSeconds: Int
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/entity/Battle.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/entity/Battle.kt
@@ -1,0 +1,81 @@
+package com.coinbattle.domain.battle.entity
+
+import com.coinbattle.domain.battle.enum.BattleStatus
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "battles")
+class Battle {
+    @Id
+    @Column(name = "battle_id", columnDefinition = "UUID")
+    val battleId: UUID = UUID.randomUUID()
+
+    @Column(name = "host_user_id", nullable = false)
+    var hostUserId: Long = 0L
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long = 0L
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: BattleStatus = BattleStatus.WAITING
+
+    @Column(name = "start_time")
+    var startTime: Instant? = null
+
+    @Column(name = "end_time")
+    var endTime: Instant? = null
+
+    @Column(name = "leverage", nullable = false)
+    var leverage: Int = 2
+
+    @Column(name = "seed_money", nullable = false)
+    var seedMoney: Long = 10_000_000
+
+    @Column(name = "duration", nullable = false)
+    var duration: Int = 10
+
+    @Column(name = "max_participants", nullable = false)
+    var maxParticipants: Int = 2
+
+    @Column(name = "current_participants", nullable = false)
+    var currentParticipants: Int = 0
+
+    @Column(name = "winner_id")
+    var winnerId: Long? = null
+
+    @Version
+    @Column(name = "version")
+    var version: Int = 0
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    var createdAt: Instant = Instant.now()
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    var updatedAt: Instant = Instant.now()
+
+    fun canAddParticipant(): Boolean = status == BattleStatus.WAITING && currentParticipants < maxParticipants
+
+    fun canStart(): Boolean = status == BattleStatus.WAITING && currentParticipants >= maxParticipants
+
+    fun start() {
+        status = BattleStatus.IN_PROGRESS
+        startTime = Instant.now()
+    }
+
+    fun finish(winnerId: Long? = null) {
+        status = BattleStatus.FINISHED
+        endTime = Instant.now()
+        this.winnerId = winnerId
+    }
+
+    fun addParticipant() {
+        currentParticipants++
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/entity/BattleSession.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/entity/BattleSession.kt
@@ -1,0 +1,24 @@
+package com.coinbattle.domain.battle.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "battle_sessions")
+class BattleSession {
+    @Id
+    @Column(name = "id", columnDefinition = "UUID")
+    val id: UUID = UUID.randomUUID()
+
+    @Column(name = "battle_id", nullable = false, columnDefinition = "UUID")
+    var battleId: UUID = UUID.randomUUID()
+
+    @Column(name = "participant_id", nullable = false)
+    var participantId: Long = 0L
+
+    @CreationTimestamp
+    @Column(name = "joined_at", updatable = false)
+    var joinedAt: Instant = Instant.now()
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/enum/BattleStatus.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/enum/BattleStatus.kt
@@ -1,0 +1,7 @@
+package com.coinbattle.domain.battle.enum
+
+enum class BattleStatus {
+    WAITING,
+    IN_PROGRESS,
+    FINISHED
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/event/BattleCreatedEvent.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/event/BattleCreatedEvent.kt
@@ -1,0 +1,7 @@
+package com.coinbattle.domain.battle.event
+
+import com.coinbattle.domain.battle.entity.Battle
+import org.springframework.context.ApplicationEvent
+import java.time.Instant
+
+class BattleCreatedEvent(source: Any, val battle: Battle, val occurredAt: Instant = Instant.now()) : ApplicationEvent(source)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleRepository.kt
@@ -1,0 +1,43 @@
+package com.coinbattle.domain.battle.repository
+
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.enum.BattleStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.*
+
+interface BattleRepository : JpaRepository<Battle, UUID> {
+
+    @Query("SELECT b FROM Battle b WHERE b.status = :status ORDER BY b.createdAt DESC")
+    fun findByStatus(@Param("status") status: BattleStatus, pageable: Pageable): Page<Battle>
+
+    @Query("""
+        SELECT b FROM Battle b
+        WHERE b.status = :status
+        AND b.currentParticipants < b.maxParticipants
+        ORDER BY b.createdAt ASC
+    """)
+    fun findJoinable(@Param("status") status: BattleStatus, pageable: Pageable): Page<Battle>
+
+    @Query("""
+        SELECT b FROM Battle b
+        WHERE b.status = :status
+        AND b.leverage = :leverage
+        AND b.seedMoney = :seedMoney
+        AND b.duration = :duration
+        AND b.maxParticipants = :maxParticipants
+        AND b.currentParticipants < b.maxParticipants
+        ORDER BY b.createdAt ASC
+    """)
+    fun findMatchingBattle(
+        @Param("status") status: BattleStatus,
+        @Param("leverage") leverage: Int,
+        @Param("seedMoney") seedMoney: Long,
+        @Param("duration") duration: Int,
+        @Param("maxParticipants") maxParticipants: Int,
+        pageable: Pageable
+    ): Page<Battle>
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleSessionRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleSessionRepository.kt
@@ -1,0 +1,49 @@
+package com.coinbattle.domain.battle.repository
+
+import com.coinbattle.domain.battle.entity.BattleSession
+import com.coinbattle.domain.battle.enum.BattleStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.*
+
+interface BattleSessionRepository : JpaRepository<BattleSession, UUID> {
+
+    @Query("SELECT bs.participantId FROM BattleSession bs WHERE bs.battleId = :battleId")
+    fun findParticipantIdsByBattleId(@Param("battleId") battleId: UUID): List<Long>
+
+    fun findByBattleId(battleId: UUID): List<BattleSession>
+
+    @Query("""
+        SELECT bs FROM BattleSession bs
+        WHERE bs.participantId = :participantId
+        AND bs.battleId = :battleId
+    """)
+    fun findByParticipantIdAndBattleId(
+        @Param("participantId") participantId: Long,
+        @Param("battleId") battleId: UUID
+    ): Optional<BattleSession>
+
+    @Query("""
+        SELECT COUNT(bs) > 0 FROM BattleSession bs
+        WHERE bs.participantId = :participantId
+        AND bs.battleId = :battleId
+    """)
+    fun existsByParticipantIdAndBattleId(
+        @Param("participantId") participantId: Long,
+        @Param("battleId") battleId: UUID
+    ): Boolean
+
+    @Query("""
+        SELECT COUNT(bs) > 0 FROM BattleSession bs
+        WHERE bs.participantId = :participantId
+        AND bs.battleId IN (
+            SELECT b.battleId FROM Battle b
+            WHERE b.status IN :activeStatuses
+        )
+    """)
+    fun existsActiveByParticipantId(
+        @Param("participantId") participantId: Long,
+        @Param("activeStatuses") activeStatuses: List<BattleStatus>
+    ): Boolean
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleMatchingService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleMatchingService.kt
@@ -1,0 +1,141 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.domain.battle.dto.request.MatchBattleRequest
+import com.coinbattle.domain.battle.dto.response.MatchFoundMessage
+import com.coinbattle.domain.battle.dto.response.MatchParticipant
+import com.coinbattle.domain.battle.dto.response.MatchQueueResponse
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.entity.BattleSession
+import com.coinbattle.domain.battle.repository.BattleRepository
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.user.repository.UserRepository
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class BattleMatchingService(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val battleRepository: BattleRepository,
+    private val battleSessionRepository: BattleSessionRepository,
+    private val userRepository: UserRepository,
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val objectMapper: ObjectMapper
+) {
+    companion object {
+        private const val ESTIMATED_WAIT_SECONDS = 30
+    }
+
+    fun joinMatchQueue(userId: Long, request: MatchBattleRequest): MatchQueueResponse {
+        val queueKey = buildQueueKey(request)
+        val userIdStr = userId.toString()
+
+        val listOps = stringRedisTemplate.opsForList()
+        val queueSize = listOps.size(queueKey) ?: 0
+
+        val alreadyInQueue = (0 until queueSize).any { idx ->
+            listOps.index(queueKey, idx) == userIdStr
+        }
+
+        if (!alreadyInQueue) {
+            listOps.rightPush(queueKey, userIdStr)
+        }
+
+        val currentSize = listOps.size(queueKey) ?: 0
+
+        if (currentSize >= request.maxParticipants) {
+            tryCreateMatchFromQueue(queueKey, request)
+        }
+
+        return MatchQueueResponse(
+            queueKey = queueKey,
+            estimatedWaitSeconds = ESTIMATED_WAIT_SECONDS
+        )
+    }
+
+    fun leaveMatchQueue(userId: Long) {
+        val pattern = "battle:queue:*"
+        val keys = stringRedisTemplate.keys(pattern)
+        val userIdStr = userId.toString()
+
+        var found = false
+        keys.forEach { key ->
+            val removed = stringRedisTemplate.opsForList().remove(key, 1, userIdStr)
+            if ((removed ?: 0) > 0) {
+                found = true
+            }
+        }
+
+        if (!found) {
+            throw CoinBattleException(ErrorCode.NOT_IN_MATCH_QUEUE)
+        }
+    }
+
+    @Transactional
+    fun tryCreateMatchFromQueue(queueKey: String, request: MatchBattleRequest) {
+        val listOps = stringRedisTemplate.opsForList()
+        val matchedUserIds = mutableListOf<Long>()
+
+        repeat(request.maxParticipants) {
+            val userIdStr = listOps.leftPop(queueKey) ?: return
+            matchedUserIds.add(userIdStr.toLong())
+        }
+
+        if (matchedUserIds.size < request.maxParticipants) {
+            matchedUserIds.forEach { uid ->
+                listOps.leftPush(queueKey, uid.toString())
+            }
+            return
+        }
+
+        val battle = Battle().apply {
+            hostUserId = matchedUserIds.first()
+            userId = matchedUserIds.first()
+            leverage = request.leverage
+            seedMoney = request.seedMoney
+            duration = request.duration
+            maxParticipants = request.maxParticipants
+            currentParticipants = matchedUserIds.size
+        }
+
+        battleRepository.save(battle)
+
+        matchedUserIds.forEach { uid ->
+            battleSessionRepository.save(
+                BattleSession().apply {
+                    battleId = battle.battleId
+                    participantId = uid
+                }
+            )
+        }
+
+        val userMap = userRepository.findAllById(matchedUserIds).associateBy { it.id }
+        val participants = matchedUserIds.map { uid ->
+            MatchParticipant(
+                userId = uid,
+                nickname = userMap[uid]?.nickname ?: ""
+            )
+        }
+
+        val message = MatchFoundMessage(
+            battleId = battle.battleId.toString(),
+            status = battle.status.name,
+            participants = participants
+        )
+
+        matchedUserIds.forEach { uid ->
+            messagingTemplate.convertAndSendToUser(
+                uid.toString(),
+                "/queue/battle/match",
+                message
+            )
+        }
+    }
+
+    private fun buildQueueKey(request: MatchBattleRequest): String =
+        "battle:queue:${request.leverage}:${request.seedMoney}:${request.duration}:${request.maxParticipants}"
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleService.kt
@@ -1,0 +1,197 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.domain.battle.dto.request.CreateBattleRequest
+import com.coinbattle.domain.battle.dto.response.BattleListResponse
+import com.coinbattle.domain.battle.dto.response.BattleMessageData
+import com.coinbattle.domain.battle.dto.response.BattleMessageType
+import com.coinbattle.domain.battle.dto.response.BattleResponse
+import com.coinbattle.domain.battle.dto.response.BattleSummary
+import com.coinbattle.domain.battle.dto.response.BattleWebSocketMessage
+import com.coinbattle.domain.battle.dto.response.JoinBattleResponse
+import com.coinbattle.domain.battle.dto.response.ParticipantInfo
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.entity.BattleSession
+import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.repository.BattleRepository
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.user.repository.UserRepository
+import org.redisson.api.RedissonClient
+import org.springframework.data.domain.PageRequest
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@Service
+class BattleService(
+    private val battleRepository: BattleRepository,
+    private val battleSessionRepository: BattleSessionRepository,
+    private val userRepository: UserRepository,
+    private val redissonClient: RedissonClient,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+    private val allowedDurations = setOf(10, 30, 60)
+    private val allowedMaxParticipants = setOf(2, 3, 5)
+
+    @Transactional
+    fun createBattle(userId: Long, request: CreateBattleRequest): BattleResponse {
+        validateCreateRequest(request)
+
+        val activeStatuses = listOf(BattleStatus.WAITING, BattleStatus.IN_PROGRESS)
+        if (battleSessionRepository.existsActiveByParticipantId(userId, activeStatuses)) {
+            throw CoinBattleException(ErrorCode.ALREADY_IN_BATTLE)
+        }
+
+        val battle = Battle().apply {
+            hostUserId = userId
+            this.userId = userId
+            leverage = request.leverage
+            seedMoney = request.seedMoney
+            duration = request.duration
+            maxParticipants = request.maxParticipants
+            currentParticipants = 1
+        }
+
+        battleRepository.save(battle)
+
+        battleSessionRepository.save(
+            BattleSession().apply {
+                battleId = battle.battleId
+                participantId = userId
+            }
+        )
+
+        return BattleResponse.from(battle)
+    }
+
+    @Transactional
+    fun joinBattle(userId: Long, battleId: UUID): JoinBattleResponse {
+        val lock = redissonClient.getLock("battle:${battleId}:join")
+        if (!lock.tryLock(0, 3, TimeUnit.SECONDS)) {
+            throw CoinBattleException(ErrorCode.BATTLE_LOCK_TIMEOUT)
+        }
+
+        try {
+            return executeJoinBattle(userId, battleId)
+        } finally {
+            if (lock.isHeldByCurrentThread) lock.unlock()
+        }
+    }
+
+    @Transactional
+    fun executeJoinBattle(userId: Long, battleId: UUID): JoinBattleResponse {
+        val alreadyInThisBattle = battleSessionRepository.existsByParticipantIdAndBattleId(userId, battleId)
+        val activeStatuses = listOf(BattleStatus.WAITING, BattleStatus.IN_PROGRESS)
+
+        if (!alreadyInThisBattle && battleSessionRepository.existsActiveByParticipantId(userId, activeStatuses)) {
+            throw CoinBattleException(ErrorCode.ALREADY_IN_BATTLE)
+        }
+
+        val battle = battleRepository.findById(battleId).orElseThrow {
+            CoinBattleException(ErrorCode.BATTLE_NOT_FOUND)
+        }
+
+        if (battle.status == BattleStatus.IN_PROGRESS || battle.status == BattleStatus.FINISHED) {
+            throw CoinBattleException(ErrorCode.BATTLE_ALREADY_STARTED)
+        }
+
+        if (!battle.canAddParticipant() && !alreadyInThisBattle) {
+            throw CoinBattleException(ErrorCode.BATTLE_FULL)
+        }
+
+        if (!alreadyInThisBattle) {
+            battle.addParticipant()
+            battleSessionRepository.save(
+                BattleSession().apply {
+                    this.battleId = battleId
+                    participantId = userId
+                }
+            )
+        }
+
+        if (battle.canStart()) {
+            battle.start()
+            broadcastBattleStarted(battle)
+        } else {
+            broadcastParticipantJoined(battle, userId)
+        }
+
+        return JoinBattleResponse.from(battle)
+    }
+
+    @Transactional(readOnly = true)
+    fun getBattle(battleId: UUID): BattleResponse {
+        val battle = battleRepository.findById(battleId).orElseThrow {
+            CoinBattleException(ErrorCode.BATTLE_NOT_FOUND)
+        }
+
+        val participantIds = battleSessionRepository.findParticipantIdsByBattleId(battleId)
+        val userMap = userRepository.findAllById(participantIds).associateBy { it.id }
+
+        val participants = participantIds.map { uid ->
+            val user = userMap[uid]
+            ParticipantInfo(
+                userId = uid,
+                nickname = user?.nickname ?: "",
+                seedPriceSnapshot = null,
+                currentValuation = null,
+                returnRate = null
+            )
+        }
+
+        return BattleResponse.from(battle, participants)
+    }
+
+    @Transactional(readOnly = true)
+    fun getBattleList(status: BattleStatus, page: Int, size: Int): BattleListResponse {
+        val pageable = PageRequest.of(page, size)
+        val battlePage = battleRepository.findByStatus(status, pageable)
+
+        return BattleListResponse(
+            content = battlePage.content.map { BattleSummary.from(it) },
+            totalElements = battlePage.totalElements,
+            totalPages = battlePage.totalPages,
+            page = page,
+            size = size
+        )
+    }
+
+    private fun validateCreateRequest(request: CreateBattleRequest) {
+        if (request.duration !in allowedDurations) {
+            throw CoinBattleException(ErrorCode.INVALID_DURATION)
+        }
+        if (request.maxParticipants !in allowedMaxParticipants) {
+            throw CoinBattleException(ErrorCode.INVALID_MAX_PARTICIPANTS)
+        }
+    }
+
+    private fun broadcastParticipantJoined(battle: Battle, userId: Long) {
+        messagingTemplate.convertAndSend(
+            "/topic/battle/${battle.battleId}",
+            BattleWebSocketMessage(
+                type = BattleMessageType.PARTICIPANT_JOINED,
+                battleId = battle.battleId.toString(),
+                data = BattleMessageData(
+                    userId = userId,
+                    currentParticipants = battle.currentParticipants
+                )
+            )
+        )
+    }
+
+    private fun broadcastBattleStarted(battle: Battle) {
+        messagingTemplate.convertAndSend(
+            "/topic/battle/${battle.battleId}",
+            BattleWebSocketMessage(
+                type = BattleMessageType.BATTLE_STARTED,
+                battleId = battle.battleId.toString(),
+                data = BattleMessageData(
+                    currentParticipants = battle.currentParticipants
+                )
+            )
+        )
+    }
+}

--- a/backend/src/main/resources/db/migration/V3__battle_schema.sql
+++ b/backend/src/main/resources/db/migration/V3__battle_schema.sql
@@ -1,0 +1,31 @@
+CREATE TABLE battles (
+    battle_id           UUID PRIMARY KEY,
+    host_user_id        BIGINT          NOT NULL,
+    user_id             BIGINT          NOT NULL,
+    status              VARCHAR(20)     NOT NULL DEFAULT 'WAITING',
+    start_time          TIMESTAMPTZ,
+    end_time            TIMESTAMPTZ,
+    leverage            INT             NOT NULL,
+    seed_money          BIGINT          NOT NULL,
+    duration            INT             NOT NULL DEFAULT 10,
+    max_participants    INT             NOT NULL DEFAULT 2,
+    current_participants INT            NOT NULL DEFAULT 0,
+    winner_id           BIGINT,
+    version             INT             NOT NULL DEFAULT 0,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE battle_sessions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    battle_id       UUID        NOT NULL REFERENCES battles(battle_id) ON DELETE CASCADE,
+    participant_id  BIGINT      NOT NULL,
+    joined_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(battle_id, participant_id)
+);
+
+CREATE INDEX idx_battles_status ON battles(status);
+CREATE INDEX idx_battles_host_user_id ON battles(host_user_id);
+CREATE INDEX idx_battles_created_at ON battles(created_at DESC);
+CREATE INDEX idx_battle_sessions_battle_id ON battle_sessions(battle_id);
+CREATE INDEX idx_battle_sessions_participant_id ON battle_sessions(participant_id);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { OAuth2Callback } from './pages/OAuth2Callback';
 import { MarketListPage } from './pages/MarketListPage';
 import { CoinDetailPage } from './pages/CoinDetailPage';
 import { RankingPage } from './pages/RankingPage';
+import { BattlePage } from './pages/BattlePage';
+import { BattleRoom } from './pages/BattleRoom';
 
 function App() {
   return (
@@ -13,7 +15,9 @@ function App() {
       <Route path="/oauth2/callback" element={<OAuth2Callback />} />
       <Route path="/" element={<AuthGuard><MarketListPage /></AuthGuard>} />
       <Route path="/coin/:ticker" element={<AuthGuard><CoinDetailPage /></AuthGuard>} />
-      <Route path="/battle" element={<AuthGuard><div>Battle</div></AuthGuard>} />
+      <Route path="/battles" element={<AuthGuard><BattlePage /></AuthGuard>} />
+      <Route path="/battles/:battleId" element={<AuthGuard><BattleRoom /></AuthGuard>} />
+      <Route path="/battle" element={<AuthGuard><BattlePage /></AuthGuard>} />
       <Route path="/ranking" element={<AuthGuard><RankingPage /></AuthGuard>} />
       <Route path="/result/:battleId" element={<AuthGuard><div>ResultCard</div></AuthGuard>} />
       <Route path="/portfolio" element={<AuthGuard><div>Portfolio</div></AuthGuard>} />

--- a/frontend/src/pages/BattlePage.tsx
+++ b/frontend/src/pages/BattlePage.tsx
@@ -1,0 +1,582 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion, AnimatePresence } from 'motion/react';
+import { useBattleStore } from '../store/useBattleStore';
+import { connectStomp, getStompClient } from '../lib/stomp';
+import type { BattleListItem, CreateBattleRequest, MatchBattleRequest } from '../types';
+
+type TabStatus = 'WAITING' | 'IN_PROGRESS';
+
+const LEVERAGE_OPTIONS = [1, 2, 3, 5, 10];
+const SEED_MONEY_OPTIONS = [100_000, 300_000, 500_000, 1_000_000];
+const DURATION_OPTIONS = [10, 30, 60];
+const MAX_PARTICIPANTS_OPTIONS = [2, 3, 5];
+
+function formatMoney(amount: number): string {
+  if (amount >= 1_000_000) return `${amount / 1_000_000}백만`;
+  if (amount >= 10_000) return `${amount / 10_000}만`;
+  return amount.toLocaleString('ko-KR');
+}
+
+function StatusBadge({ status }: { status: 'WAITING' | 'IN_PROGRESS' | 'FINISHED' }) {
+  if (status === 'WAITING') {
+    return (
+      <span className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs font-medium text-zinc-300">
+        대기 중
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full bg-[#2DD4BF]/20 px-2 py-0.5 text-xs font-medium text-[#2DD4BF]">
+      진행 중
+    </span>
+  );
+}
+
+function BattleCard({ battle, onClick }: { battle: BattleListItem; onClick: () => void }) {
+  const isFull = battle.currentParticipants >= battle.maxParticipants;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15 }}
+      onClick={onClick}
+      className="flex flex-col gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-4 cursor-pointer hover:border-zinc-600 hover:bg-zinc-800/80 transition-colors"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-orange-500/20 px-2 py-0.5 text-xs font-semibold text-orange-400">
+            {battle.leverage}x
+          </span>
+          <StatusBadge status={battle.status} />
+        </div>
+        <span className="text-xs text-zinc-600">{battle.duration}분</span>
+      </div>
+
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-xs text-zinc-500 mb-1">시드머니</p>
+          <p className="text-base font-bold text-white">
+            {formatMoney(battle.seedMoney)}
+            <span className="text-xs text-zinc-600 ml-1">원</span>
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-zinc-500 mb-1">참가 현황</p>
+          <p className={`text-base font-bold ${isFull ? 'text-red-400' : 'text-[#2DD4BF]'}`}>
+            {battle.currentParticipants}
+            <span className="text-zinc-600 font-normal">/{battle.maxParticipants}명</span>
+          </p>
+        </div>
+      </div>
+
+      {battle.status === 'WAITING' && !isFull && (
+        <div className="h-1 rounded-full bg-zinc-800 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-orange-500 to-orange-400 transition-all"
+            style={{ width: `${(battle.currentParticipants / battle.maxParticipants) * 100}%` }}
+          />
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 animate-pulse space-y-3">
+      <div className="flex items-center gap-2">
+        <div className="h-5 w-8 rounded-full bg-zinc-800" />
+        <div className="h-5 w-14 rounded-full bg-zinc-800" />
+      </div>
+      <div className="flex justify-between">
+        <div className="space-y-1">
+          <div className="h-3 w-12 rounded bg-zinc-800" />
+          <div className="h-5 w-20 rounded bg-zinc-800" />
+        </div>
+        <div className="space-y-1 items-end flex flex-col">
+          <div className="h-3 w-12 rounded bg-zinc-800" />
+          <div className="h-5 w-10 rounded bg-zinc-800" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OptionButton({
+  selected,
+  onClick,
+  children,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex-1 rounded-xl py-2 text-sm font-semibold transition-colors ${
+        selected
+          ? 'bg-orange-500 text-white'
+          : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CreateBattleModal({ onClose, onCreated }: { onClose: () => void; onCreated: (battleId: string) => void }) {
+  const createBattle = useBattleStore((s) => s.createBattle);
+  const [form, setForm] = useState<CreateBattleRequest>({
+    leverage: 5,
+    seedMoney: 1_000_000,
+    duration: 10,
+    maxParticipants: 2,
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const battleId = await createBattle(form);
+      onCreated(battleId);
+    } catch {
+      setError('배틀룸 생성에 실패했습니다');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 40 }}
+        transition={{ duration: 0.2 }}
+        className="relative w-full sm:max-w-md bg-zinc-900 rounded-t-3xl sm:rounded-2xl border border-zinc-800 p-6 z-10"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-bold text-white">배틀룸 만들기</h2>
+          <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 text-xl leading-none">✕</button>
+        </div>
+
+        <div className="space-y-5">
+          <div>
+            <p className="text-xs text-zinc-500 mb-2">레버리지</p>
+            <div className="flex gap-2">
+              {LEVERAGE_OPTIONS.map((lv) => (
+                <OptionButton
+                  key={lv}
+                  selected={form.leverage === lv}
+                  onClick={() => setForm((f) => ({ ...f, leverage: lv }))}
+                >
+                  {lv}x
+                </OptionButton>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs text-zinc-500 mb-2">시드머니</p>
+            <div className="flex gap-2 flex-wrap">
+              {SEED_MONEY_OPTIONS.map((sm) => (
+                <OptionButton
+                  key={sm}
+                  selected={form.seedMoney === sm}
+                  onClick={() => setForm((f) => ({ ...f, seedMoney: sm }))}
+                >
+                  {formatMoney(sm)}
+                </OptionButton>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs text-zinc-500 mb-2">배틀 시간</p>
+            <div className="flex gap-2">
+              {DURATION_OPTIONS.map((d) => (
+                <OptionButton
+                  key={d}
+                  selected={form.duration === d}
+                  onClick={() => setForm((f) => ({ ...f, duration: d }))}
+                >
+                  {d}분
+                </OptionButton>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs text-zinc-500 mb-2">최대 인원</p>
+            <div className="flex gap-2">
+              {MAX_PARTICIPANTS_OPTIONS.map((mp) => (
+                <OptionButton
+                  key={mp}
+                  selected={form.maxParticipants === mp}
+                  onClick={() => setForm((f) => ({ ...f, maxParticipants: mp }))}
+                >
+                  {mp}명
+                </OptionButton>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {error && <p className="mt-4 text-xs text-red-400">{error}</p>}
+
+        <motion.button
+          whileTap={{ scale: 0.97 }}
+          onClick={handleSubmit}
+          disabled={loading}
+          className="mt-6 w-full rounded-xl bg-orange-500 py-3.5 text-sm font-bold text-white hover:bg-orange-400 active:bg-orange-600 transition-colors disabled:opacity-50"
+        >
+          {loading ? '생성 중...' : '배틀룸 생성'}
+        </motion.button>
+      </motion.div>
+    </div>
+  );
+}
+
+function MatchQueueModal({ onClose }: { onClose: () => void }) {
+  const navigate = useNavigate();
+  const { matchingStatus, queueKey, enterMatchQueue, cancelMatchQueue } = useBattleStore();
+  const [form, setForm] = useState<MatchBattleRequest>({
+    leverage: 5,
+    seedMoney: 1_000_000,
+    duration: 10,
+    maxParticipants: 2,
+  });
+  const [waitSeconds, setWaitSeconds] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (matchingStatus !== 'queued') return;
+    const id = setInterval(() => setElapsed((e) => e + 1), 1000);
+    return () => clearInterval(id);
+  }, [matchingStatus]);
+
+  useEffect(() => {
+    if (matchingStatus === 'matched' && queueKey) {
+      onClose();
+      navigate(`/battles/${queueKey}`);
+    }
+  }, [matchingStatus, queueKey, navigate, onClose]);
+
+  useEffect(() => {
+    if (matchingStatus !== 'queued') return;
+
+    let active = true;
+    connectStomp().then(() => {
+      if (!active) return;
+      const client = getStompClient();
+      const sub = client.subscribe('/user/queue/battle/match', (msg) => {
+        try {
+          const notification = JSON.parse(msg.body);
+          useBattleStore.getState().setMatchedBattle(notification.battleId);
+        } catch {
+          // ignore
+        }
+      });
+      return () => sub.unsubscribe();
+    });
+
+    return () => { active = false; };
+  }, [matchingStatus]);
+
+  const handleEnterQueue = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      await enterMatchQueue(form);
+      setWaitSeconds(30);
+    } catch {
+      setError('매칭 큐 등록에 실패했습니다');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await cancelMatchQueue();
+    } catch {
+      // ignore
+    }
+  };
+
+  const isQueued = matchingStatus === 'queued';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={!isQueued ? onClose : undefined} />
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 40 }}
+        transition={{ duration: 0.2 }}
+        className="relative w-full sm:max-w-md bg-zinc-900 rounded-t-3xl sm:rounded-2xl border border-zinc-800 p-6 z-10"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-bold text-white">랜덤 매칭</h2>
+          {!isQueued && (
+            <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 text-xl leading-none">✕</button>
+          )}
+        </div>
+
+        {isQueued ? (
+          <div className="flex flex-col items-center gap-6 py-4">
+            <div className="relative">
+              <div className="w-20 h-20 rounded-full border-2 border-orange-500/30 flex items-center justify-center">
+                <motion.div
+                  animate={{ rotate: 360 }}
+                  transition={{ duration: 1.5, repeat: Infinity, ease: 'linear' }}
+                  className="w-16 h-16 rounded-full border-2 border-transparent border-t-orange-500"
+                />
+              </div>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="font-mono text-xl font-bold text-orange-400">{elapsed}s</span>
+              </div>
+            </div>
+            <div className="text-center">
+              <p className="text-white font-semibold">상대방 찾는 중...</p>
+              <p className="text-zinc-500 text-sm mt-1">
+                예상 대기 시간: {waitSeconds}초
+              </p>
+            </div>
+            <div className="w-full rounded-xl border border-zinc-800 bg-zinc-800/50 p-3 text-sm text-zinc-400 space-y-1">
+              <div className="flex justify-between">
+                <span>레버리지</span><span className="text-white font-semibold">{form.leverage}x</span>
+              </div>
+              <div className="flex justify-between">
+                <span>시드머니</span><span className="text-white font-semibold">{formatMoney(form.seedMoney)}원</span>
+              </div>
+              <div className="flex justify-between">
+                <span>배틀 시간</span><span className="text-white font-semibold">{form.duration}분</span>
+              </div>
+              <div className="flex justify-between">
+                <span>인원</span><span className="text-white font-semibold">{form.maxParticipants}명</span>
+              </div>
+            </div>
+            <button
+              onClick={handleCancel}
+              className="w-full rounded-xl border border-zinc-700 py-3 text-sm font-semibold text-zinc-400 hover:border-zinc-500 hover:text-zinc-200 transition-colors"
+            >
+              매칭 취소
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-5">
+              <div>
+                <p className="text-xs text-zinc-500 mb-2">레버리지</p>
+                <div className="flex gap-2">
+                  {LEVERAGE_OPTIONS.map((lv) => (
+                    <OptionButton key={lv} selected={form.leverage === lv} onClick={() => setForm((f) => ({ ...f, leverage: lv }))}>
+                      {lv}x
+                    </OptionButton>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500 mb-2">시드머니</p>
+                <div className="flex gap-2 flex-wrap">
+                  {SEED_MONEY_OPTIONS.map((sm) => (
+                    <OptionButton key={sm} selected={form.seedMoney === sm} onClick={() => setForm((f) => ({ ...f, seedMoney: sm }))}>
+                      {formatMoney(sm)}
+                    </OptionButton>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500 mb-2">배틀 시간</p>
+                <div className="flex gap-2">
+                  {DURATION_OPTIONS.map((d) => (
+                    <OptionButton key={d} selected={form.duration === d} onClick={() => setForm((f) => ({ ...f, duration: d }))}>
+                      {d}분
+                    </OptionButton>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500 mb-2">최대 인원</p>
+                <div className="flex gap-2">
+                  {MAX_PARTICIPANTS_OPTIONS.map((mp) => (
+                    <OptionButton key={mp} selected={form.maxParticipants === mp} onClick={() => setForm((f) => ({ ...f, maxParticipants: mp }))}>
+                      {mp}명
+                    </OptionButton>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {error && <p className="mt-4 text-xs text-red-400">{error}</p>}
+
+            <motion.button
+              whileTap={{ scale: 0.97 }}
+              onClick={handleEnterQueue}
+              disabled={loading}
+              className="mt-6 w-full rounded-xl bg-orange-500 py-3.5 text-sm font-bold text-white hover:bg-orange-400 transition-colors disabled:opacity-50"
+            >
+              {loading ? '등록 중...' : '매칭 시작'}
+            </motion.button>
+          </>
+        )}
+      </motion.div>
+    </div>
+  );
+}
+
+export function BattlePage() {
+  const navigate = useNavigate();
+  const { battles, fetchBattles } = useBattleStore();
+  const [tab, setTab] = useState<TabStatus>('WAITING');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showMatchModal, setShowMatchModal] = useState(false);
+
+  const loadBattles = async (status: TabStatus) => {
+    setIsLoading(true);
+    setIsError(false);
+    try {
+      await fetchBattles(status);
+    } catch {
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadBattles(tab);
+  }, [tab]);
+
+  const handleCreated = (battleId: string) => {
+    setShowCreateModal(false);
+    navigate(`/battles/${battleId}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0C0C0D] text-white flex flex-col">
+      <header className="sticky top-0 z-10 bg-[#0C0C0D]/95 backdrop-blur border-b border-zinc-800 px-4 py-3">
+        <div className="max-w-2xl mx-auto flex items-center gap-3">
+          <h1 className="text-lg font-extrabold bg-gradient-to-r from-orange-400 to-yellow-400 bg-clip-text text-transparent">
+            배틀
+          </h1>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={() => setShowMatchModal(true)}
+              className="px-3 py-1.5 rounded-xl border border-zinc-700 text-xs font-semibold text-zinc-300 hover:border-zinc-500 hover:text-white transition-colors"
+            >
+              랜덤 매칭
+            </button>
+            <button
+              onClick={() => setShowCreateModal(true)}
+              className="px-3 py-1.5 rounded-xl bg-orange-500 hover:bg-orange-400 text-xs font-semibold text-white transition-colors"
+            >
+              방 만들기
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="sticky top-[57px] z-10 bg-[#0C0C0D]/95 backdrop-blur border-b border-zinc-800">
+        <div className="max-w-2xl mx-auto flex">
+          {(['WAITING', 'IN_PROGRESS'] as TabStatus[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`relative flex-1 py-3 text-sm font-semibold transition-colors ${
+                tab === t ? 'text-orange-400' : 'text-zinc-500 hover:text-zinc-300'
+              }`}
+            >
+              {t === 'WAITING' ? '대기 중' : '진행 중'}
+              {tab === t && (
+                <motion.div
+                  layoutId="battle-tab-indicator"
+                  className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-400"
+                />
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <main className="max-w-2xl mx-auto w-full flex-1 p-4">
+        {isError && (
+          <div className="flex flex-col items-center justify-center py-20 gap-4">
+            <p className="text-zinc-500 text-sm">배틀 목록을 불러올 수 없습니다</p>
+            <button
+              onClick={() => loadBattles(tab)}
+              className="px-5 py-2 bg-orange-500 hover:bg-orange-400 text-white text-sm font-semibold rounded-xl transition-colors"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="grid grid-cols-1 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !isError && (
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={tab}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="grid grid-cols-1 gap-3"
+            >
+              {battles.map((battle) => (
+                <BattleCard
+                  key={battle.battleId}
+                  battle={battle}
+                  onClick={() => navigate(`/battles/${battle.battleId}`)}
+                />
+              ))}
+              {battles.length === 0 && (
+                <div className="flex flex-col items-center justify-center py-20 gap-3">
+                  <p className="text-zinc-600 text-sm">
+                    {tab === 'WAITING' ? '대기 중인 배틀이 없습니다' : '진행 중인 배틀이 없습니다'}
+                  </p>
+                  {tab === 'WAITING' && (
+                    <button
+                      onClick={() => setShowCreateModal(true)}
+                      className="px-5 py-2 bg-orange-500 hover:bg-orange-400 text-white text-sm font-semibold rounded-xl transition-colors"
+                    >
+                      방 만들기
+                    </button>
+                  )}
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        )}
+      </main>
+
+      <AnimatePresence>
+        {showCreateModal && (
+          <CreateBattleModal onClose={() => setShowCreateModal(false)} onCreated={handleCreated} />
+        )}
+        {showMatchModal && (
+          <MatchQueueModal onClose={() => setShowMatchModal(false)} />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/pages/BattleRoom.tsx
+++ b/frontend/src/pages/BattleRoom.tsx
@@ -1,0 +1,468 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { motion, AnimatePresence } from 'motion/react';
+import type { StompSubscription } from '@stomp/stompjs';
+import { connectStomp, getStompClient } from '../lib/stomp';
+import { useBattleStore } from '../store/useBattleStore';
+import type { BattleRankingEntry, BattleStompMessage } from '../types';
+
+function formatMoney(amount: number): string {
+  if (amount >= 1_000_000) return `${(amount / 1_000_000).toFixed(1)}백만`;
+  if (amount >= 10_000) return `${Math.floor(amount / 10_000)}만`;
+  return amount.toLocaleString('ko-KR');
+}
+
+function formatReturnRate(rate: number): string {
+  const sign = rate > 0 ? '+' : '';
+  return `${sign}${rate.toFixed(2)}%`;
+}
+
+function getRankMeta(rank: number): { color: string; label: string } {
+  if (rank === 1) return { color: '#FFD700', label: '1위' };
+  if (rank === 2) return { color: '#C0C0C0', label: '2위' };
+  if (rank === 3) return { color: '#CD7F32', label: '3위' };
+  return { color: '', label: `${rank}위` };
+}
+
+function useCountdown(endTime: string | null): string {
+  const [remaining, setRemaining] = useState('');
+
+  useEffect(() => {
+    if (!endTime) return;
+
+    const update = () => {
+      const diff = new Date(endTime).getTime() - Date.now();
+      if (diff <= 0) {
+        setRemaining('00:00');
+        return;
+      }
+      const m = Math.floor(diff / 60_000);
+      const s = Math.floor((diff % 60_000) / 1000);
+      setRemaining(`${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`);
+    };
+
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [endTime]);
+
+  return remaining;
+}
+
+function RankingRow({ entry, index }: { entry: BattleRankingEntry; index: number }) {
+  const meta = getRankMeta(entry.rank);
+  const isPositive = entry.returnRate >= 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15, delay: Math.min(index * 0.05, 0.3) }}
+      className="flex items-center px-4 py-3 border-b border-zinc-800/60 hover:bg-zinc-800/40 transition-colors"
+    >
+      <span
+        className="text-sm font-bold w-8 text-center shrink-0"
+        style={meta.color ? { color: meta.color } : { color: '#71717a' }}
+      >
+        {meta.label}
+      </span>
+      <span className="text-sm text-white flex-1 truncate ml-3">{entry.nickname}</span>
+      <div className="text-right shrink-0">
+        <p className={`text-sm font-bold font-mono ${isPositive ? 'text-[#2DD4BF]' : 'text-red-400'}`}>
+          {formatReturnRate(entry.returnRate)}
+        </p>
+        <p className="text-xs text-zinc-600 font-mono">
+          {formatMoney(entry.currentValuation)}원
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
+function BattleInfoCard({
+  leverage,
+  seedMoney,
+  duration,
+  status,
+}: {
+  leverage: number;
+  seedMoney: number;
+  duration: number;
+  status: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4">
+      <div className="grid grid-cols-4 gap-3">
+        <div className="flex flex-col items-center gap-1">
+          <span className="text-xs text-zinc-500">레버리지</span>
+          <span className="rounded-full bg-orange-500/20 px-2 py-0.5 text-xs font-bold text-orange-400">
+            {leverage}x
+          </span>
+        </div>
+        <div className="flex flex-col items-center gap-1">
+          <span className="text-xs text-zinc-500">시드</span>
+          <span className="text-xs font-semibold text-white">{formatMoney(seedMoney)}</span>
+        </div>
+        <div className="flex flex-col items-center gap-1">
+          <span className="text-xs text-zinc-500">시간</span>
+          <span className="text-xs font-semibold text-white">{duration}분</span>
+        </div>
+        <div className="flex flex-col items-center gap-1">
+          <span className="text-xs text-zinc-500">상태</span>
+          {status === 'WAITING' && (
+            <span className="text-xs font-semibold text-zinc-400">대기</span>
+          )}
+          {status === 'IN_PROGRESS' && (
+            <span className="text-xs font-semibold text-[#2DD4BF]">진행중</span>
+          )}
+          {status === 'FINISHED' && (
+            <span className="text-xs font-semibold text-zinc-500">종료</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WaitingView({
+  battleId,
+  currentParticipants,
+  maxParticipants,
+  participants,
+}: {
+  battleId: string;
+  currentParticipants: number;
+  maxParticipants: number;
+  participants: Array<{ userId: number; nickname: string; returnRate: number; currentValuation: number }>;
+}) {
+  const { joinBattle } = useBattleStore();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const isFull = currentParticipants >= maxParticipants;
+
+  const handleJoin = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      await joinBattle(battleId);
+    } catch {
+      setError('참가에 실패했습니다. 이미 참가했거나 인원이 가득 찼습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+      className="flex flex-col gap-4"
+    >
+      <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-semibold text-zinc-300">참가자</p>
+          <span className={`text-sm font-bold ${isFull ? 'text-red-400' : 'text-[#2DD4BF]'}`}>
+            {currentParticipants}/{maxParticipants}명
+          </span>
+        </div>
+        <div className="h-1.5 rounded-full bg-zinc-800 overflow-hidden mb-4">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-orange-500 to-orange-400 transition-all"
+            style={{ width: `${(currentParticipants / maxParticipants) * 100}%` }}
+          />
+        </div>
+        <div className="space-y-2">
+          {participants.map((p) => (
+            <div key={p.userId} className="flex items-center gap-3 py-2 border-b border-zinc-800/60 last:border-0">
+              <div className="w-8 h-8 rounded-full bg-gradient-to-br from-orange-500 to-pink-500 flex items-center justify-center text-xs font-bold text-white">
+                {p.nickname.charAt(0).toUpperCase()}
+              </div>
+              <span className="text-sm text-white">{p.nickname}</span>
+            </div>
+          ))}
+          {Array.from({ length: maxParticipants - currentParticipants }).map((_, i) => (
+            <div key={`empty-${i}`} className="flex items-center gap-3 py-2 border-b border-zinc-800/60 last:border-0">
+              <div className="w-8 h-8 rounded-full border-2 border-dashed border-zinc-700" />
+              <span className="text-sm text-zinc-600">대기 중...</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {error && <p className="text-xs text-red-400 px-1">{error}</p>}
+
+      <motion.button
+        whileTap={{ scale: 0.97 }}
+        onClick={handleJoin}
+        disabled={loading || isFull}
+        className="w-full rounded-2xl bg-orange-500 py-4 text-base font-bold text-white hover:bg-orange-400 active:bg-orange-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {loading ? '참가 중...' : isFull ? '인원 가득' : '참가하기'}
+      </motion.button>
+    </motion.div>
+  );
+}
+
+function InProgressView({
+  endTime,
+  rankings,
+}: {
+  endTime: string | null;
+  rankings: BattleRankingEntry[];
+}) {
+  const remaining = useCountdown(endTime);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+      className="flex flex-col gap-4"
+    >
+      <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 flex flex-col items-center gap-2">
+        <p className="text-xs text-zinc-500">남은 시간</p>
+        <span className="font-mono text-4xl font-bold text-orange-400 tabular-nums">
+          {remaining || '--:--'}
+        </span>
+      </div>
+
+      <div className="rounded-2xl border border-zinc-800 bg-zinc-900 overflow-hidden">
+        <div className="flex items-center px-4 py-2 border-b border-zinc-800 text-xs text-zinc-600">
+          <div className="w-8 text-center shrink-0">순위</div>
+          <div className="flex-1 ml-3">닉네임</div>
+          <div className="shrink-0 text-right">수익률 / 평가</div>
+        </div>
+        <AnimatePresence mode="popLayout">
+          {rankings.map((entry, index) => (
+            <RankingRow key={entry.userId} entry={entry} index={index} />
+          ))}
+        </AnimatePresence>
+        {rankings.length === 0 && (
+          <p className="text-center py-8 text-zinc-600 text-sm">순위 데이터 없음</p>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function FinishedView({
+  rankings,
+  winnerId,
+}: {
+  rankings: BattleRankingEntry[];
+  winnerId: number | null;
+}) {
+  const navigate = useNavigate();
+  const winner = rankings.find((r) => r.userId === winnerId) ?? rankings[0];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+      className="flex flex-col gap-4"
+    >
+      {winner && (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.3, delay: 0.1 }}
+          className="rounded-2xl border border-yellow-500/30 bg-yellow-500/5 p-5 flex flex-col items-center gap-3"
+        >
+          <span className="text-3xl">🏆</span>
+          <div className="text-center">
+            <p className="text-xs text-zinc-500 mb-1">우승자</p>
+            <p className="text-xl font-bold text-white">{winner.nickname}</p>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="text-center">
+              <p className="text-xs text-zinc-500 mb-0.5">수익률</p>
+              <p className={`text-xl font-bold font-mono ${winner.returnRate >= 0 ? 'text-[#2DD4BF]' : 'text-red-400'}`}>
+                {formatReturnRate(winner.returnRate)}
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-xs text-zinc-500 mb-0.5">최종 평가</p>
+              <p className="text-sm font-semibold text-white font-mono">
+                {formatMoney(winner.currentValuation)}원
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      )}
+
+      <div className="rounded-2xl border border-zinc-800 bg-zinc-900 overflow-hidden">
+        <div className="flex items-center px-4 py-2 border-b border-zinc-800 text-xs text-zinc-600">
+          <div className="w-8 text-center shrink-0">순위</div>
+          <div className="flex-1 ml-3">닉네임</div>
+          <div className="shrink-0 text-right">수익률 / 평가</div>
+        </div>
+        {rankings.map((entry, index) => (
+          <RankingRow key={entry.userId} entry={entry} index={index} />
+        ))}
+      </div>
+
+      <button
+        onClick={() => navigate('/battles')}
+        className="w-full rounded-2xl border border-zinc-700 py-3.5 text-sm font-semibold text-zinc-300 hover:border-zinc-500 hover:text-white transition-colors"
+      >
+        배틀 목록으로
+      </button>
+    </motion.div>
+  );
+}
+
+export function BattleRoom() {
+  const { battleId } = useParams<{ battleId: string }>();
+  const navigate = useNavigate();
+  const { currentBattle, rankings, fetchBattle, updateRankings, setBattleStatus } = useBattleStore();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const subRef = useRef<StompSubscription | null>(null);
+
+  useEffect(() => {
+    if (!battleId) return;
+
+    setIsLoading(true);
+    setIsError(false);
+    fetchBattle(battleId)
+      .catch(() => setIsError(true))
+      .finally(() => setIsLoading(false));
+  }, [battleId]);
+
+  useEffect(() => {
+    if (!battleId) return;
+    let mounted = true;
+
+    connectStomp().then(() => {
+      if (!mounted) return;
+      const client = getStompClient();
+      subRef.current = client.subscribe(`/topic/battle/${battleId}`, (msg) => {
+        try {
+          const message: BattleStompMessage = JSON.parse(msg.body);
+          if (message.type === 'RANK_UPDATE' && message.data.rankings) {
+            updateRankings(message.data.rankings);
+          }
+          if (message.type === 'BATTLE_STARTED') {
+            setBattleStatus('IN_PROGRESS');
+            fetchBattle(battleId);
+          }
+          if (message.type === 'BATTLE_FINISHED') {
+            setBattleStatus('FINISHED');
+            fetchBattle(battleId);
+          }
+          if (message.type === 'PARTICIPANT_JOINED') {
+            fetchBattle(battleId);
+          }
+        } catch {
+          // ignore malformed frames
+        }
+      });
+    });
+
+    return () => {
+      mounted = false;
+      subRef.current?.unsubscribe();
+      subRef.current = null;
+    };
+  }, [battleId]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-[#0C0C0D] flex flex-col">
+        <header className="sticky top-0 z-10 bg-[#0C0C0D]/95 backdrop-blur border-b border-zinc-800 px-4 py-3">
+          <div className="max-w-2xl mx-auto flex items-center gap-3">
+            <div className="w-7 h-7 rounded-lg bg-zinc-800 animate-pulse" />
+            <div className="h-5 w-32 rounded bg-zinc-800 animate-pulse" />
+          </div>
+        </header>
+        <main className="max-w-2xl mx-auto w-full flex-1 p-4 space-y-3">
+          <div className="h-20 rounded-2xl bg-zinc-900 animate-pulse" />
+          <div className="h-40 rounded-2xl bg-zinc-900 animate-pulse" />
+        </main>
+      </div>
+    );
+  }
+
+  if (isError || !currentBattle) {
+    return (
+      <div className="min-h-screen bg-[#0C0C0D] flex flex-col items-center justify-center gap-4">
+        <p className="text-zinc-500 text-sm">배틀 정보를 불러올 수 없습니다</p>
+        <button
+          onClick={() => navigate('/battles')}
+          className="px-5 py-2 bg-orange-500 hover:bg-orange-400 text-white text-sm font-semibold rounded-xl transition-colors"
+        >
+          목록으로
+        </button>
+      </div>
+    );
+  }
+
+  const participantsList = currentBattle.participants.map((p) => ({
+    userId: p.userId,
+    nickname: p.nickname,
+    returnRate: p.returnRate,
+    currentValuation: p.currentValuation,
+  }));
+
+  const topNicknames = currentBattle.participants.slice(0, 2).map((p) => p.nickname).join(' vs ');
+
+  return (
+    <div className="min-h-screen bg-[#0C0C0D] text-white flex flex-col">
+      <header className="sticky top-0 z-10 bg-[#0C0C0D]/95 backdrop-blur border-b border-zinc-800 px-4 py-3">
+        <div className="max-w-2xl mx-auto flex items-center gap-3">
+          <button
+            onClick={() => navigate('/battles')}
+            className="w-7 h-7 rounded-lg bg-zinc-800 hover:bg-zinc-700 flex items-center justify-center text-zinc-400 hover:text-white transition-colors text-sm"
+          >
+            ←
+          </button>
+          <h1 className="text-sm font-bold text-white truncate flex-1">
+            {topNicknames || `배틀 ${currentBattle.battleId.slice(0, 8)}`}
+          </h1>
+          {currentBattle.status === 'IN_PROGRESS' && (
+            <span className="rounded-full bg-[#2DD4BF]/20 px-2 py-0.5 text-xs font-medium text-[#2DD4BF] shrink-0">
+              진행 중
+            </span>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto w-full flex-1 p-4 space-y-4">
+        <BattleInfoCard
+          leverage={currentBattle.leverage}
+          seedMoney={currentBattle.seedMoney}
+          duration={currentBattle.duration}
+          status={currentBattle.status}
+        />
+
+        <AnimatePresence mode="wait">
+          {currentBattle.status === 'WAITING' && (
+            <WaitingView
+              key="waiting"
+              battleId={currentBattle.battleId}
+              currentParticipants={currentBattle.participants.length}
+              maxParticipants={currentBattle.maxParticipants}
+              participants={participantsList}
+            />
+          )}
+          {currentBattle.status === 'IN_PROGRESS' && (
+            <InProgressView
+              key="in-progress"
+              endTime={currentBattle.endTime}
+              rankings={rankings}
+            />
+          )}
+          {currentBattle.status === 'FINISHED' && (
+            <FinishedView
+              key="finished"
+              rankings={rankings}
+              winnerId={currentBattle.winnerId}
+            />
+          )}
+        </AnimatePresence>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/store/useBattleStore.ts
+++ b/frontend/src/store/useBattleStore.ts
@@ -1,0 +1,111 @@
+import { create } from 'zustand';
+import { api } from '../lib/api';
+import type {
+  BattleListItem,
+  BattleDetail,
+  BattleRankingEntry,
+  BattleStatus,
+  CreateBattleRequest,
+  MatchBattleRequest,
+} from '../types';
+
+interface BattleStore {
+  battles: BattleListItem[];
+  currentBattle: BattleDetail | null;
+  rankings: BattleRankingEntry[];
+  matchingStatus: 'idle' | 'queued' | 'matched';
+  queueKey: string | null;
+
+  fetchBattles: (status?: string) => Promise<void>;
+  fetchBattle: (battleId: string) => Promise<void>;
+  createBattle: (req: CreateBattleRequest) => Promise<string>;
+  joinBattle: (battleId: string) => Promise<void>;
+  enterMatchQueue: (req: MatchBattleRequest) => Promise<void>;
+  cancelMatchQueue: () => Promise<void>;
+  updateRankings: (rankings: BattleRankingEntry[]) => void;
+  setBattleStatus: (status: BattleStatus) => void;
+  setMatchedBattle: (battleId: string) => void;
+}
+
+export const useBattleStore = create<BattleStore>((set, get) => ({
+  battles: [],
+  currentBattle: null,
+  rankings: [],
+  matchingStatus: 'idle',
+  queueKey: null,
+
+  fetchBattles: async (status = 'WAITING') => {
+    const response = await api.get('/api/battles', { params: { status, page: 0, size: 20 } });
+    set({ battles: response.data.content });
+  },
+
+  fetchBattle: async (battleId) => {
+    const response = await api.get(`/api/battles/${battleId}`);
+    const battle: BattleDetail = response.data;
+    set({
+      currentBattle: battle,
+      rankings: battle.participants.map((p, i) => ({
+        rank: i + 1,
+        userId: p.userId,
+        nickname: p.nickname,
+        returnRate: p.returnRate,
+        currentValuation: p.currentValuation,
+      })),
+    });
+  },
+
+  createBattle: async (req) => {
+    const response = await api.post('/api/battles', req);
+    const created = response.data;
+    set((state) => ({ battles: [created, ...state.battles] }));
+    return created.battleId as string;
+  },
+
+  joinBattle: async (battleId) => {
+    const response = await api.post(`/api/battles/${battleId}/join`);
+    const joined = response.data;
+    set((state) => ({
+      currentBattle: state.currentBattle
+        ? {
+            ...state.currentBattle,
+            status: joined.status,
+            currentParticipants: joined.currentParticipants,
+            startTime: joined.startTime,
+          }
+        : state.currentBattle,
+    }));
+  },
+
+  enterMatchQueue: async (req) => {
+    const response = await api.post('/api/battles/match', req);
+    set({ matchingStatus: 'queued', queueKey: response.data.queueKey });
+  },
+
+  cancelMatchQueue: async () => {
+    const { queueKey } = get();
+    if (!queueKey) return;
+    await api.delete('/api/battles/match');
+    set({ matchingStatus: 'idle', queueKey: null });
+  },
+
+  updateRankings: (rankings) => {
+    set({ rankings });
+    set((state) => ({
+      currentBattle: state.currentBattle
+        ? { ...state.currentBattle }
+        : state.currentBattle,
+    }));
+  },
+
+  setBattleStatus: (status) => {
+    set((state) => ({
+      currentBattle: state.currentBattle
+        ? { ...state.currentBattle, status }
+        : state.currentBattle,
+    }));
+  },
+
+  setMatchedBattle: (battleId) => {
+    set({ matchingStatus: 'matched', queueKey: battleId });
+  },
+}));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -121,3 +121,110 @@ export interface MyRanking {
   season: MyRankingSlot;
   daily: MyRankingSlot;
 }
+
+export type BattleStatus = 'WAITING' | 'IN_PROGRESS' | 'FINISHED';
+
+export interface BattleListItem {
+  battleId: string;
+  status: BattleStatus;
+  leverage: number;
+  seedMoney: number;
+  duration: number;
+  maxParticipants: number;
+  currentParticipants: number;
+  createdAt: string;
+}
+
+export interface BattleParticipant {
+  userId: number;
+  nickname: string;
+  seedPriceSnapshot: number | null;
+  currentValuation: number;
+  returnRate: number;
+}
+
+export interface BattleDetail {
+  battleId: string;
+  status: BattleStatus;
+  leverage: number;
+  seedMoney: number;
+  duration: number;
+  maxParticipants: number;
+  startTime: string | null;
+  endTime: string | null;
+  participants: BattleParticipant[];
+  winnerId: number | null;
+}
+
+export interface BattleListResponse {
+  content: BattleListItem[];
+  totalElements: number;
+  totalPages: number;
+  page: number;
+  size: number;
+}
+
+export interface CreateBattleRequest {
+  leverage: number;
+  seedMoney: number;
+  duration: number;
+  maxParticipants: number;
+}
+
+export interface CreateBattleResponse {
+  battleId: string;
+  status: BattleStatus;
+  hostUserId: number;
+  leverage: number;
+  seedMoney: number;
+  duration: number;
+  maxParticipants: number;
+  currentParticipants: number;
+  createdAt: string;
+}
+
+export interface JoinBattleResponse {
+  battleId: string;
+  status: BattleStatus;
+  currentParticipants: number;
+  maxParticipants: number;
+  startTime: string;
+}
+
+export interface MatchBattleRequest {
+  leverage: number;
+  seedMoney: number;
+  duration: number;
+  maxParticipants: number;
+}
+
+export interface MatchQueueResponse {
+  queueKey: string;
+  estimatedWaitSeconds: number;
+}
+
+export interface BattleRankingEntry {
+  rank: number;
+  userId: number;
+  nickname: string;
+  returnRate: number;
+  currentValuation: number;
+}
+
+export interface BattleStompMessage {
+  type: 'PARTICIPANT_JOINED' | 'BATTLE_STARTED' | 'RANK_UPDATE' | 'BATTLE_FINISHED';
+  battleId: string;
+  data: {
+    userId: number | null;
+    currentParticipants: number;
+    rankings: BattleRankingEntry[];
+    winnerId: number | null;
+  };
+  timestamp: string;
+}
+
+export interface MatchNotification {
+  battleId: string;
+  status: BattleStatus;
+  participants: Array<{ userId: number; nickname: string }>;
+}


### PR DESCRIPTION
## 개요

CoinBattle PVP 배틀 모드의 기반을 구축합니다. 배틀 엔티티 설계, Redis 기반 랜덤 매칭, WebSocket 실시간 브로드캐스트, 프론트엔드 배틀 화면까지 전체 배틀 플로우를 구현합니다.

## 변경 내용

- `Battle` / `BattleSession` 엔티티 및 `BattleStatus` enum 추가
- `BattleService` — 배틀 생성/참가/종료 로직 (Redisson 분산 락 + 낙관적 락)
- `BattleMatchingService` — Redis List 기반 랜덤 매칭 큐, 정원 충족 시 배틀 자동 생성
- `BattleController` — 6개 REST 엔드포인트 (생성/참가/조회/목록/매칭 등록·취소)
- WebSocket STOMP: `/topic/battle/{battleId}` 브로드캐스트, `/user/queue/battle/match` 개인 알림
- DB 마이그레이션: `V3__battle_schema.sql` (battles, battle_sessions 테이블)
- `BattlePage.tsx` — 배틀룸 목록 (대기 중/진행 중 탭, 방 만들기 모달, 랜덤 매칭 모달)
- `BattleRoom.tsx` — 배틀 상세 화면 (WAITING/IN_PROGRESS/FINISHED 상태별 UI, 실시간 순위표)
- `useBattleStore.ts` — 배틀 상태 Zustand 스토어 (ApiResponse 래퍼 대응)

## 관련 이슈

Close #14