### PR TITLE
[feat]: 배틀 종료 결과 처리 및 결과 공유 카드 #20

### DIFF
--- a/backend/src/main/kotlin/com/coinbattle/common/exception/ErrorCode.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/exception/ErrorCode.kt
@@ -29,4 +29,6 @@ enum class ErrorCode(val status: Int, val message: String) {
     BATTLE_FULL(409, "배틀 참가자가 가득 찼습니다"),
     BATTLE_LOCK_TIMEOUT(423, "배틀 처리 중입니다. 잠시 후 다시 시도해주세요"),
     NOT_IN_MATCH_QUEUE(404, "매칭 큐에 등록되지 않은 상태입니다"),
+    BATTLE_NOT_FINISHED(409, "배틀이 아직 종료되지 않았습니다"),
+    BATTLE_ACCESS_DENIED(403, "배틀 참가자만 결과를 조회할 수 있습니다"),
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/controller/BattleController.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/controller/BattleController.kt
@@ -5,9 +5,11 @@ import com.coinbattle.domain.battle.dto.request.CreateBattleRequest
 import com.coinbattle.domain.battle.dto.request.MatchBattleRequest
 import com.coinbattle.domain.battle.dto.response.BattleListResponse
 import com.coinbattle.domain.battle.dto.response.BattleResponse
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
 import com.coinbattle.domain.battle.dto.response.JoinBattleResponse
 import com.coinbattle.domain.battle.dto.response.MatchQueueResponse
 import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.service.BattleEndService
 import com.coinbattle.domain.battle.service.BattleMatchingService
 import com.coinbattle.domain.battle.service.BattleService
 import com.coinbattle.domain.user.entity.CoinBattlePrincipal
@@ -29,7 +31,8 @@ import java.util.UUID
 @RequestMapping("/api/battles")
 class BattleController(
     private val battleService: BattleService,
-    private val battleMatchingService: BattleMatchingService
+    private val battleMatchingService: BattleMatchingService,
+    private val battleEndService: BattleEndService
 ) {
     @PostMapping
     fun createBattle(
@@ -82,5 +85,14 @@ class BattleController(
     ): ResponseEntity<Void> {
         battleMatchingService.leaveMatchQueue(principal.user.id)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/{battleId}/result")
+    fun getBattleResult(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal,
+        @PathVariable battleId: UUID
+    ): ResponseEntity<ApiResponse<BattleResultResponse>> {
+        val result = battleEndService.getBattleResult(battleId, principal.user.id)
+        return ResponseEntity.ok(ApiResponse.ok(result))
     }
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleResultResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleResultResponse.kt
@@ -1,0 +1,24 @@
+package com.coinbattle.domain.battle.dto.response
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class BattleResultResponse(
+    val battleId: String,
+    val status: String,
+    val durationMinutes: Int,
+    val endedAt: String?,
+    val participants: List<ParticipantResultResponse>,
+    val myResult: ParticipantResultResponse?
+)
+
+data class ParticipantResultResponse(
+    val userId: Long,
+    val nickname: String,
+    val rank: Int,
+    val isWinner: Boolean,
+    val initialSeed: Long,
+    val finalValuation: Long,
+    val profitAmount: Long,
+    val profitRate: Double
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/entity/BattleSession.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/entity/BattleSession.kt
@@ -21,4 +21,10 @@ class BattleSession {
     @CreationTimestamp
     @Column(name = "joined_at", updatable = false)
     var joinedAt: Instant = Instant.now()
+
+    @Column(name = "final_valuation")
+    var finalValuation: Long? = null
+
+    @Column(name = "rank")
+    var rank: Int? = null
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.Instant
 import java.util.*
 
 interface BattleRepository : JpaRepository<Battle, UUID> {
@@ -40,4 +41,10 @@ interface BattleRepository : JpaRepository<Battle, UUID> {
         @Param("maxParticipants") maxParticipants: Int,
         pageable: Pageable
     ): Page<Battle>
+
+    @Query("SELECT b FROM Battle b WHERE b.status = :status AND b.startTime IS NOT NULL AND b.startTime <= :expiredBefore")
+    fun findExpiredBattles(
+        @Param("status") status: BattleStatus,
+        @Param("expiredBefore") expiredBefore: Instant
+    ): List<Battle>
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleEndService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleEndService.kt
@@ -1,0 +1,191 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.domain.battle.dto.response.BattleMessageData
+import com.coinbattle.domain.battle.dto.response.BattleMessageType
+import com.coinbattle.domain.battle.dto.response.BattleRankEntry
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
+import com.coinbattle.domain.battle.dto.response.BattleWebSocketMessage
+import com.coinbattle.domain.battle.dto.response.ParticipantResultResponse
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.entity.BattleSession
+import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.repository.BattleRepository
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.order.entity.PositionStatus
+import com.coinbattle.domain.order.repository.PositionRepository
+import com.coinbattle.domain.user.entity.User
+import com.coinbattle.domain.user.repository.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@Service
+class BattleEndService(
+    private val battleRepository: BattleRepository,
+    private val battleSessionRepository: BattleSessionRepository,
+    private val userRepository: UserRepository,
+    private val positionRepository: PositionRepository,
+    private val tickerRedisRepository: TickerRedisRepository,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+    @Autowired
+    @Lazy
+    private lateinit var self: BattleEndService
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelay = 30_000)
+    fun processExpiredBattles() {
+        val now = Instant.now()
+        val minDurationExpiredBefore = now.minus(10, ChronoUnit.MINUTES)
+        val expiredBattles = battleRepository.findExpiredBattles(BattleStatus.IN_PROGRESS, minDurationExpiredBefore)
+
+        expiredBattles.forEach { battle ->
+            try {
+                self.finishBattleInTransaction(battle, now)
+            } catch (e: Exception) {
+                logger.error("배틀 종료 처리 실패 battleId=${battle.battleId}", e)
+            }
+        }
+    }
+
+    @Transactional
+    fun finishBattleInTransaction(battle: Battle, now: Instant) {
+        val expiredBefore = now.minus(battle.duration.toLong(), ChronoUnit.MINUTES)
+        val startTime = battle.startTime ?: return
+        if (startTime.isAfter(expiredBefore)) return
+
+        val sessions = battleSessionRepository.findByBattleId(battle.battleId)
+        val participantIds = sessions.map { it.participantId }
+        val userMap = userRepository.findAllById(participantIds).associateBy { it.id }
+
+        val valuations = sessions.map { session ->
+            val user = userMap[session.participantId]
+                ?: return@map SessionValuation(session, 0L)
+            val finalValuation = calculateFinalValuation(user)
+            SessionValuation(session, finalValuation)
+        }
+
+        val ranked = valuations.sortedByDescending { it.finalValuation }
+
+        ranked.forEachIndexed { index, sv ->
+            sv.session.finalValuation = sv.finalValuation
+            sv.session.rank = index + 1
+            battleSessionRepository.save(sv.session)
+        }
+
+        val winnerId = ranked.firstOrNull()?.session?.participantId
+        battle.finish(winnerId)
+        battleRepository.save(battle)
+
+        broadcastBattleFinished(battle, ranked, userMap)
+    }
+
+    @Transactional(readOnly = true)
+    fun getBattleResult(battleId: UUID, currentUserId: Long): BattleResultResponse {
+        val battle = battleRepository.findById(battleId).orElseThrow {
+            CoinBattleException(ErrorCode.BATTLE_NOT_FOUND)
+        }
+
+        if (battle.status != BattleStatus.FINISHED) {
+            throw CoinBattleException(ErrorCode.BATTLE_NOT_FINISHED)
+        }
+
+        val sessions = battleSessionRepository.findByBattleId(battleId)
+        val participantIds = sessions.map { it.participantId }
+
+        if (currentUserId !in participantIds) {
+            throw CoinBattleException(ErrorCode.BATTLE_ACCESS_DENIED)
+        }
+
+        val userMap = userRepository.findAllById(participantIds).associateBy { it.id }
+
+        val participants = sessions.map { session ->
+            val user = userMap[session.participantId]
+            val finalValuation = session.finalValuation ?: 0L
+            val profitAmount = finalValuation - battle.seedMoney
+            val profitRate = if (battle.seedMoney > 0) {
+                profitAmount.toDouble() / battle.seedMoney * 100.0
+            } else 0.0
+
+            ParticipantResultResponse(
+                userId = session.participantId,
+                nickname = user?.nickname ?: "",
+                rank = session.rank ?: 0,
+                isWinner = session.participantId == battle.winnerId,
+                initialSeed = battle.seedMoney,
+                finalValuation = finalValuation,
+                profitAmount = profitAmount,
+                profitRate = profitRate
+            )
+        }.sortedBy { it.rank }
+
+        val myResult = participants.find { it.userId == currentUserId }
+
+        return BattleResultResponse(
+            battleId = battleId.toString(),
+            status = battle.status.name,
+            durationMinutes = battle.duration,
+            endedAt = battle.endTime?.toString(),
+            participants = participants,
+            myResult = myResult
+        )
+    }
+
+    private fun calculateFinalValuation(user: User): Long {
+        val openPositions = positionRepository.findByUserIdAndStatus(user.id, PositionStatus.OPEN)
+        val positionValue = openPositions.sumOf { position ->
+            val currentPrice = tickerRedisRepository.findByMarket(position.ticker)?.tradePrice?.toLong()
+                ?: position.averagePrice
+            position.evaluatedValue(currentPrice)
+        }
+        return user.balance + positionValue
+    }
+
+    private fun broadcastBattleFinished(
+        battle: Battle,
+        ranked: List<SessionValuation>,
+        userMap: Map<Long, User>
+    ) {
+        val rankings = ranked.mapIndexed { index, sv ->
+            val user = userMap[sv.session.participantId]
+            val returnRate = if (battle.seedMoney > 0) {
+                (sv.finalValuation - battle.seedMoney).toDouble() / battle.seedMoney * 100.0
+            } else 0.0
+            BattleRankEntry(
+                rank = index + 1,
+                userId = sv.session.participantId,
+                nickname = user?.nickname ?: "",
+                returnRate = returnRate,
+                currentValuation = sv.finalValuation
+            )
+        }
+
+        messagingTemplate.convertAndSend(
+            "/topic/battle/${battle.battleId}",
+            BattleWebSocketMessage(
+                type = BattleMessageType.BATTLE_FINISHED,
+                battleId = battle.battleId.toString(),
+                data = BattleMessageData(
+                    rankings = rankings,
+                    winnerId = battle.winnerId
+                )
+            )
+        )
+    }
+
+    private data class SessionValuation(
+        val session: BattleSession,
+        val finalValuation: Long
+    )
+}

--- a/backend/src/main/resources/db/migration/V4__battle_result_columns.sql
+++ b/backend/src/main/resources/db/migration/V4__battle_result_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE battle_sessions
+    ADD COLUMN final_valuation BIGINT,
+    ADD COLUMN rank INT;

--- a/backend/src/test/kotlin/com/coinbattle/domain/battle/BattleEndServiceTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/battle/BattleEndServiceTest.kt
@@ -1,0 +1,231 @@
+package com.coinbattle.domain.battle
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.entity.BattleSession
+import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.repository.BattleRepository
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.battle.service.BattleEndService
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.order.entity.OrderDirection
+import com.coinbattle.domain.order.entity.Position
+import com.coinbattle.domain.order.entity.PositionStatus
+import com.coinbattle.domain.order.repository.PositionRepository
+import com.coinbattle.domain.user.entity.AuthProvider
+import com.coinbattle.domain.user.entity.User
+import com.coinbattle.domain.user.repository.UserRepository
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BattleEndServiceTest {
+
+    @MockK
+    lateinit var battleRepository: BattleRepository
+
+    @MockK
+    lateinit var battleSessionRepository: BattleSessionRepository
+
+    @MockK
+    lateinit var userRepository: UserRepository
+
+    @MockK
+    lateinit var positionRepository: PositionRepository
+
+    @MockK
+    lateinit var tickerRedisRepository: TickerRedisRepository
+
+    @MockK
+    lateinit var messagingTemplate: SimpMessagingTemplate
+
+    lateinit var battleEndService: BattleEndService
+
+    @BeforeEach
+    fun setUp() {
+        battleEndService = BattleEndService(
+            battleRepository,
+            battleSessionRepository,
+            userRepository,
+            positionRepository,
+            tickerRedisRepository,
+            messagingTemplate
+        )
+    }
+
+    @Test
+    fun `배틀_종료_시_참가자별_수익률_계산_정확도`() {
+        val userId1 = 1L
+        val userId2 = 2L
+
+        val battle = createInProgressBattle(userId1, durationMinutes = 10)
+        battle.startTime = Instant.now().minusSeconds(700)
+
+        val session1 = createBattleSession(battle.battleId, userId1)
+        val session2 = createBattleSession(battle.battleId, userId2)
+
+        val user1 = createUser(userId1, balance = 5_000_000L)
+        val user2 = createUser(userId2, balance = 8_000_000L)
+
+        val position1 = createPosition(userId1, "KRW-BTC", 100_000L, BigDecimal("0.05"), 2, 5_000_000L)
+        val ticker = mockk<com.coinbattle.domain.market.dto.response.TickerResponse> {
+            every { tradePrice } returns 110_000.0
+        }
+
+        every { battleSessionRepository.findByBattleId(battle.battleId) } returns listOf(session1, session2)
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(user1, user2)
+        every { positionRepository.findByUserIdAndStatus(userId1, PositionStatus.OPEN) } returns listOf(position1)
+        every { positionRepository.findByUserIdAndStatus(userId2, PositionStatus.OPEN) } returns emptyList()
+        every { tickerRedisRepository.findByMarket("KRW-BTC") } returns ticker
+        every { battleRepository.save(any()) } answers { firstArg() }
+        every { battleSessionRepository.save(any()) } answers { firstArg() }
+        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+
+        battleEndService.finishBattleInTransaction(battle, Instant.now())
+
+        verify { battleSessionRepository.save(match { it.participantId == userId2 && it.finalValuation == 8_000_000L }) }
+        verify { battleSessionRepository.save(match { it.participantId == userId1 && it.finalValuation != null }) }
+    }
+
+    @Test
+    fun `배틀_종료_시_승자_결정`() {
+        val userId1 = 1L
+        val userId2 = 2L
+
+        val battle = createInProgressBattle(userId1, durationMinutes = 10)
+        battle.startTime = Instant.now().minusSeconds(700)
+
+        val session1 = createBattleSession(battle.battleId, userId1)
+        val session2 = createBattleSession(battle.battleId, userId2)
+
+        val user1 = createUser(userId1, balance = 5_000_000L)
+        val user2 = createUser(userId2, balance = 12_000_000L)
+
+        every { battleSessionRepository.findByBattleId(battle.battleId) } returns listOf(session1, session2)
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(user1, user2)
+        every { positionRepository.findByUserIdAndStatus(userId1, PositionStatus.OPEN) } returns emptyList()
+        every { positionRepository.findByUserIdAndStatus(userId2, PositionStatus.OPEN) } returns emptyList()
+        every { battleRepository.save(any()) } answers { firstArg() }
+        every { battleSessionRepository.save(any()) } answers { firstArg() }
+        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+
+        battleEndService.finishBattleInTransaction(battle, Instant.now())
+
+        verify {
+            battleRepository.save(match { it.winnerId == userId2 && it.status == BattleStatus.FINISHED })
+        }
+    }
+
+    @Test
+    fun `배틀_결과_조회_미종료_시_예외`() {
+        val battleId = UUID.randomUUID()
+        val userId = 1L
+
+        val battle = createInProgressBattle(userId, durationMinutes = 10)
+
+        every { battleRepository.findById(battleId) } returns Optional.of(battle)
+
+        assertThatThrownBy {
+            battleEndService.getBattleResult(battleId, userId)
+        }
+            .isInstanceOf(CoinBattleException::class.java)
+            .hasMessageContaining("아직 종료되지 않았습니다")
+    }
+
+    @Test
+    fun `배틀_결과_조회_비참가자_접근_차단`() {
+        val battleId = UUID.randomUUID()
+        val hostId = 1L
+        val outsiderId = 99L
+
+        val battle = createFinishedBattle(hostId)
+
+        every { battleRepository.findById(battleId) } returns Optional.of(battle)
+        every { battleSessionRepository.findByBattleId(battleId) } returns listOf(
+            createBattleSession(battleId, hostId)
+        )
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(createUser(hostId, balance = 10_000_000L))
+
+        assertThatThrownBy {
+            battleEndService.getBattleResult(battleId, outsiderId)
+        }
+            .isInstanceOf(CoinBattleException::class.java)
+            .hasMessageContaining("참가자만 결과를 조회할 수 있습니다")
+    }
+
+    private fun createInProgressBattle(hostUserId: Long, durationMinutes: Int): Battle {
+        return Battle().apply {
+            this.hostUserId = hostUserId
+            this.userId = hostUserId
+            this.status = BattleStatus.IN_PROGRESS
+            this.duration = durationMinutes
+            this.startTime = Instant.now()
+        }
+    }
+
+    private fun createFinishedBattle(hostUserId: Long): Battle {
+        return Battle().apply {
+            this.hostUserId = hostUserId
+            this.userId = hostUserId
+            this.status = BattleStatus.FINISHED
+            this.duration = 10
+            this.startTime = Instant.now().minusSeconds(700)
+            this.endTime = Instant.now()
+        }
+    }
+
+    private fun createBattleSession(battleId: UUID, participantId: Long): BattleSession {
+        return BattleSession().apply {
+            this.battleId = battleId
+            this.participantId = participantId
+        }
+    }
+
+    private fun createUser(id: Long, balance: Long): User {
+        val user = User(
+            email = "user$id@test.com",
+            nickname = "user$id",
+            provider = AuthProvider.KAKAO,
+            providerId = "provider_$id",
+            balance = balance
+        )
+        val field = User::class.java.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(user, id)
+        return user
+    }
+
+    private fun createPosition(
+        userId: Long,
+        ticker: String,
+        averagePrice: Long,
+        quantity: BigDecimal,
+        leverage: Int,
+        margin: Long
+    ): Position {
+        return Position(
+            userId = userId,
+            ticker = ticker,
+            direction = OrderDirection.LONG,
+            quantity = quantity,
+            averagePrice = averagePrice,
+            leverage = leverage,
+            margin = margin,
+            status = PositionStatus.OPEN
+        )
+    }
+}

--- a/frontend/src/components/BattleResultCard.tsx
+++ b/frontend/src/components/BattleResultCard.tsx
@@ -1,0 +1,305 @@
+// ============================================================================
+// CUSTOMIZATION — 브랜드 컬러·텍스트만 이 구역에서 수정
+// ============================================================================
+
+const COLORS = {
+  background: '#0C0C0D',
+  cardBg: '#18181B',
+  cardBorder: '#27272A',
+  accent: '#FF6B35',
+  accentSecondary: '#2DD4BF',
+  profit: '#2DD4BF',
+  loss: '#f87171',
+  gold: '#FFD700',
+  silver: '#C0C0C0',
+  bronze: '#CD7F32',
+} as const;
+
+const SHARE_TEXT = (rank: number, profitRate: number, finalValuation: number) =>
+  `🏆 CoinBattle 결과\n${rank}위 | ${profitRate > 0 ? '+' : ''}${profitRate.toFixed(2)}%\n최종 평가금: ${finalValuation.toLocaleString('ko-KR')}원`;
+
+// ============================================================================
+// END CUSTOMIZATION
+// ============================================================================
+
+import { motion, AnimatePresence } from 'motion/react';
+import { useNavigate } from 'react-router-dom';
+import type { BattleResultResponse, ParticipantResultResponse } from '../types';
+
+interface BattleResultCardProps {
+  result: BattleResultResponse;
+  currentUserId: number;
+  onClose: () => void;
+}
+
+function formatMoney(amount: number): string {
+  if (amount >= 1_000_000) return `${(amount / 1_000_000).toFixed(1)}백만`;
+  if (amount >= 10_000) return `${Math.floor(amount / 10_000)}만`;
+  return amount.toLocaleString('ko-KR');
+}
+
+function formatProfitRate(rate: number): string {
+  const sign = rate > 0 ? '+' : '';
+  return `${sign}${rate.toFixed(2)}%`;
+}
+
+function getRankColor(rank: number): string {
+  if (rank === 1) return COLORS.gold;
+  if (rank === 2) return COLORS.silver;
+  if (rank === 3) return COLORS.bronze;
+  return '#71717a';
+}
+
+function RankMedal({ rank }: { rank: number }) {
+  if (rank === 1) return <span className="text-lg">🥇</span>;
+  if (rank === 2) return <span className="text-lg">🥈</span>;
+  if (rank === 3) return <span className="text-lg">🥉</span>;
+  return (
+    <span className="text-sm font-bold tabular-nums" style={{ color: getRankColor(rank) }}>
+      {rank}위
+    </span>
+  );
+}
+
+function ParticipantRow({
+  participant,
+  isMe,
+  index,
+}: {
+  participant: ParticipantResultResponse;
+  isMe: boolean;
+  index: number;
+}) {
+  const isProfit = participant.profitRate >= 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -12 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.25, delay: 0.1 + index * 0.06 }}
+      className={`flex items-center gap-3 px-4 py-3 border-b last:border-0 transition-colors ${
+        isMe
+          ? 'border-orange-500/30 bg-orange-500/5'
+          : 'border-zinc-800/60 hover:bg-zinc-800/30'
+      }`}
+    >
+      <div className="w-10 flex items-center justify-center shrink-0">
+        <RankMedal rank={participant.rank} />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-semibold text-white truncate">{participant.nickname}</span>
+          {isMe && (
+            <span className="shrink-0 rounded-full bg-orange-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-orange-400">
+              나
+            </span>
+          )}
+          {participant.isWinner && (
+            <span className="shrink-0 text-sm">🏆</span>
+          )}
+        </div>
+        <p className="text-xs text-zinc-500 font-mono mt-0.5">
+          {formatMoney(participant.finalValuation)}원
+        </p>
+      </div>
+
+      <div className="text-right shrink-0">
+        <p
+          className="text-sm font-bold font-mono"
+          style={{ color: isProfit ? COLORS.profit : COLORS.loss }}
+        >
+          {formatProfitRate(participant.profitRate)}
+        </p>
+        <p className="text-xs text-zinc-600 font-mono mt-0.5">
+          {isProfit ? '+' : ''}{formatMoney(participant.profitAmount)}원
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
+export function BattleResultCard({ result, currentUserId, onClose }: BattleResultCardProps) {
+  const navigate = useNavigate();
+  const winner = result.participants.find((p) => p.isWinner) ?? result.participants[0];
+  const myResult = result.myResult;
+
+  const handleShare = async () => {
+    if (!myResult) return;
+    const text = SHARE_TEXT(myResult.rank, myResult.profitRate, myResult.finalValuation);
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: 'CoinBattle 결과', text });
+      } catch {
+        // 사용자가 취소한 경우 무시
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(text);
+        alert('결과가 클립보드에 복사되었습니다!');
+      } catch {
+        // clipboard 접근 불가 시 무시
+      }
+    }
+  };
+
+  const handleNavigateToBattles = () => {
+    onClose();
+    navigate('/battles');
+  };
+
+  const sortedParticipants = [...result.participants].sort((a, b) => a.rank - b.rank);
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4"
+        style={{ backgroundColor: 'rgba(12, 12, 13, 0.92)', backdropFilter: 'blur(8px)' }}
+        onClick={onClose}
+      >
+        <motion.div
+          initial={{ opacity: 0, y: 40, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 20, scale: 0.97 }}
+          transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+          className="w-full max-w-md rounded-3xl border overflow-hidden"
+          style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="relative overflow-hidden">
+            <div className="pointer-events-none absolute -top-16 -right-16 w-48 h-48 rounded-full bg-gradient-to-br from-orange-500/20 via-pink-500/10 to-cyan-400/10 blur-2xl" />
+
+            <div className="flex flex-col items-center gap-2 px-6 pt-8 pb-6">
+              <motion.div
+                initial={{ scale: 0, rotate: -20 }}
+                animate={{ scale: 1, rotate: 0 }}
+                transition={{ duration: 0.4, delay: 0.1, type: 'spring', stiffness: 200 }}
+                className="text-5xl"
+              >
+                🏆
+              </motion.div>
+
+              {winner && (
+                <>
+                  <motion.div
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3, delay: 0.2 }}
+                    className="text-center"
+                  >
+                    <p className="text-xs font-semibold tracking-widest uppercase text-zinc-500 mb-1">
+                      우승자
+                    </p>
+                    <p className="text-xl font-bold text-white">{winner.nickname}</p>
+                  </motion.div>
+
+                  <motion.div
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3, delay: 0.25 }}
+                    className="flex items-center gap-4 mt-1"
+                  >
+                    <div className="text-center">
+                      <p className="text-xs text-zinc-500 mb-0.5">수익률</p>
+                      <p
+                        className="text-2xl font-bold font-mono"
+                        style={{ color: winner.profitRate >= 0 ? COLORS.profit : COLORS.loss }}
+                      >
+                        {formatProfitRate(winner.profitRate)}
+                      </p>
+                    </div>
+                    <div className="w-px h-8 bg-zinc-700" />
+                    <div className="text-center">
+                      <p className="text-xs text-zinc-500 mb-0.5">최종 평가</p>
+                      <p className="text-base font-semibold text-white font-mono">
+                        {formatMoney(winner.finalValuation)}원
+                      </p>
+                    </div>
+                  </motion.div>
+                </>
+              )}
+
+              {myResult && (
+                <motion.div
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3, delay: 0.3 }}
+                  className="w-full mt-2 rounded-xl px-4 py-2.5 flex items-center justify-between"
+                  style={{ backgroundColor: 'rgba(255, 107, 53, 0.08)', border: '1px solid rgba(255, 107, 53, 0.2)' }}
+                >
+                  <span className="text-xs font-semibold text-orange-400">내 결과</span>
+                  <div className="flex items-center gap-3">
+                    <span
+                      className="text-sm font-bold font-mono"
+                      style={{ color: myResult.profitRate >= 0 ? COLORS.profit : COLORS.loss }}
+                    >
+                      {formatProfitRate(myResult.profitRate)}
+                    </span>
+                    <span className="text-xs text-zinc-500 font-mono">
+                      {myResult.rank}위
+                    </span>
+                  </div>
+                </motion.div>
+              )}
+            </div>
+          </div>
+
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.3, delay: 0.15 }}
+            className="border-t mx-4 rounded-2xl overflow-hidden mb-4"
+            style={{ borderColor: COLORS.cardBorder, backgroundColor: '#0f0f10' }}
+          >
+            <div
+              className="flex items-center px-4 py-2 text-xs text-zinc-600 border-b"
+              style={{ borderColor: COLORS.cardBorder }}
+            >
+              <div className="w-10 text-center shrink-0">순위</div>
+              <div className="flex-1 ml-3">닉네임</div>
+              <div className="text-right">수익률 / 손익</div>
+            </div>
+            {sortedParticipants.map((participant, index) => (
+              <ParticipantRow
+                key={participant.userId}
+                participant={participant}
+                isMe={participant.userId === currentUserId}
+                index={index}
+              />
+            ))}
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.35 }}
+            className="flex flex-col gap-2.5 px-4 pb-6"
+          >
+            <motion.button
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              onClick={handleShare}
+              className="w-full rounded-2xl py-3.5 text-sm font-bold text-white transition-all"
+              style={{ backgroundColor: COLORS.accent }}
+            >
+              공유하기
+            </motion.button>
+
+            <button
+              onClick={handleNavigateToBattles}
+              className="w-full rounded-2xl border py-3.5 text-sm font-semibold text-zinc-300 hover:text-white transition-colors"
+              style={{ borderColor: COLORS.cardBorder }}
+            >
+              배틀 목록으로
+            </button>
+          </motion.div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/hooks/useBattleResult.ts
+++ b/frontend/src/hooks/useBattleResult.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { ApiResponse, BattleResultResponse } from '../types';
+
+export function useBattleResult(battleId: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ['battle-result', battleId],
+    queryFn: () =>
+      api
+        .get<ApiResponse<BattleResultResponse>>(`/api/battles/${battleId}/result`)
+        .then((r) => r.data.data),
+    enabled: !!battleId && enabled,
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/pages/BattleRoom.tsx
+++ b/frontend/src/pages/BattleRoom.tsx
@@ -4,7 +4,20 @@ import { motion, AnimatePresence } from 'motion/react';
 import type { StompSubscription } from '@stomp/stompjs';
 import { connectStomp, getStompClient } from '../lib/stomp';
 import { useBattleStore } from '../store/useBattleStore';
+import { useAuthStore } from '../store/authStore';
+import { useBattleResult } from '../hooks/useBattleResult';
+import { BattleResultCard } from '../components/BattleResultCard';
 import type { BattleRankingEntry, BattleStompMessage } from '../types';
+
+function parseUserIdFromToken(token: string | null): number {
+  if (!token) return 0;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return Number(payload.sub ?? payload.userId ?? payload.id ?? 0);
+  } catch {
+    return 0;
+  }
+}
 
 function formatMoney(amount: number): string {
   if (amount >= 1_000_000) return `${(amount / 1_000_000).toFixed(1)}백만`;
@@ -250,9 +263,11 @@ function InProgressView({
 function FinishedView({
   rankings,
   winnerId,
+  onShowResultCard,
 }: {
   rankings: BattleRankingEntry[];
   winnerId: number | null;
+  onShowResultCard: () => void;
 }) {
   const navigate = useNavigate();
   const winner = rankings.find((r) => r.userId === winnerId) ?? rankings[0];
@@ -304,6 +319,15 @@ function FinishedView({
         ))}
       </div>
 
+      <motion.button
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        onClick={onShowResultCard}
+        className="w-full rounded-2xl bg-orange-500 py-3.5 text-sm font-bold text-white hover:bg-orange-400 transition-colors"
+      >
+        결과 카드 보기
+      </motion.button>
+
       <button
         onClick={() => navigate('/battles')}
         className="w-full rounded-2xl border border-zinc-700 py-3.5 text-sm font-semibold text-zinc-300 hover:border-zinc-500 hover:text-white transition-colors"
@@ -318,9 +342,17 @@ export function BattleRoom() {
   const { battleId } = useParams<{ battleId: string }>();
   const navigate = useNavigate();
   const { currentBattle, rankings, fetchBattle, updateRankings, setBattleStatus } = useBattleStore();
+  const { accessToken } = useAuthStore();
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [showResultCard, setShowResultCard] = useState(false);
   const subRef = useRef<StompSubscription | null>(null);
+
+  const currentUserId = parseUserIdFromToken(accessToken);
+  const { data: battleResult } = useBattleResult(
+    battleId,
+    showResultCard || currentBattle?.status === 'FINISHED'
+  );
 
   useEffect(() => {
     if (!battleId) return;
@@ -352,6 +384,7 @@ export function BattleRoom() {
           if (message.type === 'BATTLE_FINISHED') {
             setBattleStatus('FINISHED');
             fetchBattle(battleId);
+            setShowResultCard(true);
           }
           if (message.type === 'PARTICIPANT_JOINED') {
             fetchBattle(battleId);
@@ -460,10 +493,19 @@ export function BattleRoom() {
               key="finished"
               rankings={rankings}
               winnerId={currentBattle.winnerId}
+              onShowResultCard={() => setShowResultCard(true)}
             />
           )}
         </AnimatePresence>
       </main>
+
+      {showResultCard && battleResult && (
+        <BattleResultCard
+          result={battleResult}
+          currentUserId={currentUserId}
+          onClose={() => setShowResultCard(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -228,3 +228,23 @@ export interface MatchNotification {
   status: BattleStatus;
   participants: Array<{ userId: number; nickname: string }>;
 }
+
+export interface ParticipantResultResponse {
+  userId: number;
+  nickname: string;
+  rank: number;
+  isWinner: boolean;
+  initialSeed: number;
+  finalValuation: number;
+  profitAmount: number;
+  profitRate: number;
+}
+
+export interface BattleResultResponse {
+  battleId: string;
+  status: string;
+  durationMinutes: number;
+  endedAt: string | null;
+  participants: ParticipantResultResponse[];
+  myResult: ParticipantResultResponse | null;
+}


### PR DESCRIPTION
## 개요

PVP 배틀 종료 시 참가자별 최종 수익률을 계산하고 승자를 결정합니다. 결과는 DB에 저장되고 랭킹이 갱신됩니다. 프론트엔드에서 결과 카드 컴포넌트를 표시하고 Web Share API로 공유할 수 있습니다.

## 변경 내용

- `BattleEndService.kt` — 30초 스케줄러로 만료 배틀 자동 종료, 참가자별 수익률 계산, STOMP BATTLE_FINISHED 브로드캐스트
- `V4__battle_result_columns.sql` — battle_sessions 테이블에 final_valuation, rank 컬럼 추가
- `GET /api/battles/{battleId}/result` 엔드포인트 추가 (BattleController)
- `BattleResultCard.tsx` — 전체 화면 오버레이 결과 카드 (Web Share API + 클립보드 fallback)
- `useBattleResult.ts` — 결과 조회 TanStack Query 훅
- `BattleRoom.tsx` — BATTLE_FINISHED 수신 시 자동 결과 카드 표시, FinishedView에 결과 카드 열람 버튼 추가

## 관련 이슈

Close #20