### PR TITLE
[feat]: 배틀 실시간 랭킹 브로드캐스트 #22

### DIFF
--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleRepository.kt
@@ -47,4 +47,6 @@ interface BattleRepository : JpaRepository<Battle, UUID> {
         @Param("status") status: BattleStatus,
         @Param("expiredBefore") expiredBefore: Instant
     ): List<Battle>
+
+    fun findAllByStatus(status: BattleStatus): List<Battle>
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/scheduler/BattleRankingScheduler.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/scheduler/BattleRankingScheduler.kt
@@ -1,0 +1,83 @@
+package com.coinbattle.domain.battle.scheduler
+
+import com.coinbattle.domain.battle.dto.response.BattleMessageData
+import com.coinbattle.domain.battle.dto.response.BattleMessageType
+import com.coinbattle.domain.battle.dto.response.BattleRankEntry
+import com.coinbattle.domain.battle.dto.response.BattleWebSocketMessage
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.repository.BattleRepository
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.order.entity.PositionStatus
+import com.coinbattle.domain.order.repository.PositionRepository
+import com.coinbattle.domain.user.repository.UserRepository
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class BattleRankingScheduler(
+    private val battleRepository: BattleRepository,
+    private val battleSessionRepository: BattleSessionRepository,
+    private val userRepository: UserRepository,
+    private val positionRepository: PositionRepository,
+    private val tickerRedisRepository: TickerRedisRepository,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+    @Scheduled(fixedDelay = 5_000)
+    @Transactional(readOnly = true)
+    fun broadcastRankings() {
+        val activeBattles = battleRepository.findAllByStatus(BattleStatus.IN_PROGRESS)
+        activeBattles.forEach { battle ->
+            runCatching { broadcastBattleRanking(battle) }
+        }
+    }
+
+    private fun broadcastBattleRanking(battle: Battle) {
+        val participantIds = battleSessionRepository.findParticipantIdsByBattleId(battle.battleId)
+        if (participantIds.isEmpty()) return
+
+        val users = userRepository.findAllById(participantIds).associateBy { it.id }
+        val openPositions = positionRepository
+            .findAllByUserIdInAndStatus(participantIds, PositionStatus.OPEN)
+            .groupBy { it.userId }
+
+        val tickers = openPositions.values.flatten().map { it.ticker }.distinct()
+        val priceMap = tickers.associate { ticker ->
+            ticker to (tickerRedisRepository.findByMarket(ticker)?.tradePrice?.toLong() ?: 0L)
+        }
+
+        val rankings = participantIds.mapNotNull { userId ->
+            val user = users[userId] ?: return@mapNotNull null
+            val positions = openPositions[userId] ?: emptyList()
+            val positionsValue = positions.sumOf { pos ->
+                val price = priceMap[pos.ticker] ?: 0L
+                if (price > 0) pos.evaluatedValue(price) else 0L
+            }
+            val finalValuation = user.balance + positionsValue
+            val returnRate = (finalValuation - battle.seedMoney).toDouble() / battle.seedMoney * 100
+            Triple(userId, user.nickname, finalValuation to returnRate)
+        }.sortedByDescending { it.third.first }
+
+        val rankEntries = rankings.mapIndexed { index, (userId, nickname, valuationPair) ->
+            BattleRankEntry(
+                rank = index + 1,
+                userId = userId,
+                nickname = nickname,
+                returnRate = Math.round(valuationPair.second * 100.0) / 100.0,
+                currentValuation = valuationPair.first
+            )
+        }
+
+        messagingTemplate.convertAndSend(
+            "/topic/battle/${battle.battleId}",
+            BattleWebSocketMessage(
+                type = BattleMessageType.RANK_UPDATE,
+                battleId = battle.battleId.toString(),
+                data = BattleMessageData(rankings = rankEntries)
+            )
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/repository/PositionRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/repository/PositionRepository.kt
@@ -16,4 +16,6 @@ interface PositionRepository : JpaRepository<Position, Long> {
         status: PositionStatus
     ): Position?
     fun findAllByStatus(status: PositionStatus): List<Position>
+
+    fun findAllByUserIdInAndStatus(userIds: List<Long>, status: PositionStatus): List<Position>
 }

--- a/backend/src/test/kotlin/com/coinbattle/domain/battle/BattleRankingSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/battle/BattleRankingSchedulerTest.kt
@@ -1,0 +1,243 @@
+package com.coinbattle.domain.battle
+
+import com.coinbattle.domain.battle.dto.response.BattleWebSocketMessage
+import com.coinbattle.domain.battle.entity.Battle
+import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.repository.BattleRepository
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.battle.scheduler.BattleRankingScheduler
+import com.coinbattle.domain.market.dto.response.ChangeType
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.order.entity.OrderDirection
+import com.coinbattle.domain.order.entity.Position
+import com.coinbattle.domain.order.entity.PositionStatus
+import com.coinbattle.domain.order.repository.PositionRepository
+import com.coinbattle.domain.user.entity.AuthProvider
+import com.coinbattle.domain.user.entity.User
+import com.coinbattle.domain.user.repository.UserRepository
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BattleRankingSchedulerTest {
+
+    @MockK
+    lateinit var battleRepository: BattleRepository
+
+    @MockK
+    lateinit var battleSessionRepository: BattleSessionRepository
+
+    @MockK
+    lateinit var userRepository: UserRepository
+
+    @MockK
+    lateinit var positionRepository: PositionRepository
+
+    @MockK
+    lateinit var tickerRedisRepository: TickerRedisRepository
+
+    @MockK
+    lateinit var messagingTemplate: SimpMessagingTemplate
+
+    lateinit var scheduler: BattleRankingScheduler
+
+    @BeforeEach
+    fun setUp() {
+        scheduler = BattleRankingScheduler(
+            battleRepository,
+            battleSessionRepository,
+            userRepository,
+            positionRepository,
+            tickerRedisRepository,
+            messagingTemplate
+        )
+    }
+
+    @Test
+    fun `IN_PROGRESS_배틀_없으면_브로드캐스트_안함`() {
+        every { battleRepository.findAllByStatus(BattleStatus.IN_PROGRESS) } returns emptyList()
+
+        scheduler.broadcastRankings()
+
+        verify(exactly = 0) { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+    }
+
+    @Test
+    fun `참가자_평가금액_내림차순_정렬_확인`() {
+        val battle = createInProgressBattle(seedMoney = 10_000_000L)
+        val userId1 = 1L
+        val userId2 = 2L
+
+        every { battleRepository.findAllByStatus(BattleStatus.IN_PROGRESS) } returns listOf(battle)
+        every { battleSessionRepository.findParticipantIdsByBattleId(battle.battleId) } returns listOf(userId1, userId2)
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(
+            createUser(userId1, balance = 7_000_000L),
+            createUser(userId2, balance = 12_000_000L)
+        )
+        every { positionRepository.findAllByUserIdInAndStatus(any(), PositionStatus.OPEN) } returns emptyList()
+        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+
+        scheduler.broadcastRankings()
+
+        val messageSlot = slot<BattleWebSocketMessage>()
+        verify { messagingTemplate.convertAndSend(any<String>(), capture(messageSlot)) }
+
+        val rankings = messageSlot.captured.data.rankings!!
+        assertThat(rankings).hasSize(2)
+        assertThat(rankings[0].rank).isEqualTo(1)
+        assertThat(rankings[0].currentValuation).isEqualTo(12_000_000L)
+        assertThat(rankings[1].rank).isEqualTo(2)
+        assertThat(rankings[1].currentValuation).isEqualTo(7_000_000L)
+    }
+
+    @Test
+    fun `오픈포지션_없는_참가자는_잔고만_반영`() {
+        val battle = createInProgressBattle(seedMoney = 10_000_000L)
+        val userId = 1L
+        val userBalance = 9_500_000L
+
+        every { battleRepository.findAllByStatus(BattleStatus.IN_PROGRESS) } returns listOf(battle)
+        every { battleSessionRepository.findParticipantIdsByBattleId(battle.battleId) } returns listOf(userId)
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(
+            createUser(userId, balance = userBalance)
+        )
+        every { positionRepository.findAllByUserIdInAndStatus(any(), PositionStatus.OPEN) } returns emptyList()
+        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+
+        scheduler.broadcastRankings()
+
+        val messageSlot = slot<BattleWebSocketMessage>()
+        verify { messagingTemplate.convertAndSend(any<String>(), capture(messageSlot)) }
+
+        val rankings = messageSlot.captured.data.rankings!!
+        assertThat(rankings).hasSize(1)
+        assertThat(rankings[0].currentValuation).isEqualTo(userBalance)
+    }
+
+    @Test
+    fun `특정_배틀_실패해도_다른_배틀_계속_처리`() {
+        val failingBattle = createInProgressBattle(seedMoney = 10_000_000L)
+        val successBattle = createInProgressBattle(seedMoney = 10_000_000L)
+        val userId = 1L
+
+        every { battleRepository.findAllByStatus(BattleStatus.IN_PROGRESS) } returns listOf(failingBattle, successBattle)
+
+        every { battleSessionRepository.findParticipantIdsByBattleId(failingBattle.battleId) } throws RuntimeException("DB 오류")
+
+        every { battleSessionRepository.findParticipantIdsByBattleId(successBattle.battleId) } returns listOf(userId)
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(
+            createUser(userId, balance = 10_000_000L)
+        )
+        every { positionRepository.findAllByUserIdInAndStatus(any(), PositionStatus.OPEN) } returns emptyList()
+        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+
+        scheduler.broadcastRankings()
+
+        verify(exactly = 1) { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+    }
+
+    @Test
+    fun `오픈포지션_평가금액이_잔고에_합산됨`() {
+        val battle = createInProgressBattle(seedMoney = 10_000_000L)
+        val userId = 1L
+        val userBalance = 5_000_000L
+
+        val position = createPosition(
+            userId = userId,
+            ticker = "KRW-BTC",
+            averagePrice = 100_000_000L,
+            quantity = BigDecimal("0.1"),
+            leverage = 2,
+            margin = 5_000_000L
+        )
+        val ticker = createTickerResponse("KRW-BTC", tradePrice = 110_000_000.0)
+
+        every { battleRepository.findAllByStatus(BattleStatus.IN_PROGRESS) } returns listOf(battle)
+        every { battleSessionRepository.findParticipantIdsByBattleId(battle.battleId) } returns listOf(userId)
+        every { userRepository.findAllById(any<Iterable<Long>>()) } returns listOf(
+            createUser(userId, balance = userBalance)
+        )
+        every { positionRepository.findAllByUserIdInAndStatus(any(), PositionStatus.OPEN) } returns listOf(position)
+        every { tickerRedisRepository.findByMarket("KRW-BTC") } returns ticker
+        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+
+        scheduler.broadcastRankings()
+
+        val messageSlot = slot<BattleWebSocketMessage>()
+        verify { messagingTemplate.convertAndSend(any<String>(), capture(messageSlot)) }
+
+        val rankings = messageSlot.captured.data.rankings!!
+        val positionEvaluated = position.evaluatedValue(110_000_000L)
+        assertThat(rankings[0].currentValuation).isEqualTo(userBalance + positionEvaluated)
+    }
+
+    private fun createInProgressBattle(seedMoney: Long): Battle {
+        return Battle().apply {
+            this.status = BattleStatus.IN_PROGRESS
+            this.seedMoney = seedMoney
+            this.startTime = Instant.now().minusSeconds(60)
+        }
+    }
+
+    private fun createUser(id: Long, balance: Long): User {
+        val user = User(
+            email = "user$id@test.com",
+            nickname = "user$id",
+            provider = AuthProvider.KAKAO,
+            providerId = "provider_$id",
+            balance = balance
+        )
+        val field = User::class.java.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(user, id)
+        return user
+    }
+
+    private fun createPosition(
+        userId: Long,
+        ticker: String,
+        averagePrice: Long,
+        quantity: BigDecimal,
+        leverage: Int,
+        margin: Long
+    ): Position {
+        return Position(
+            userId = userId,
+            ticker = ticker,
+            direction = OrderDirection.LONG,
+            quantity = quantity,
+            averagePrice = averagePrice,
+            leverage = leverage,
+            margin = margin,
+            status = PositionStatus.OPEN
+        )
+    }
+
+    private fun createTickerResponse(market: String, tradePrice: Double): TickerResponse {
+        return TickerResponse(
+            market = market,
+            tradePrice = tradePrice,
+            changeRate = 0.0,
+            changePrice = 0.0,
+            change = ChangeType.RISE,
+            accTradeVolume24h = 0.0,
+            accTradePrice24h = 0.0,
+            highPrice = tradePrice,
+            lowPrice = tradePrice
+        )
+    }
+}

--- a/frontend/src/store/useBattleStore.ts
+++ b/frontend/src/store/useBattleStore.ts
@@ -90,11 +90,6 @@ export const useBattleStore = create<BattleStore>((set, get) => ({
 
   updateRankings: (rankings) => {
     set({ rankings });
-    set((state) => ({
-      currentBattle: state.currentBattle
-        ? { ...state.currentBattle }
-        : state.currentBattle,
-    }));
   },
 
   setBattleStatus: (status) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -217,7 +217,7 @@ export interface BattleStompMessage {
   data: {
     userId: number | null;
     currentParticipants: number;
-    rankings: BattleRankingEntry[];
+    rankings?: BattleRankingEntry[];
     winnerId: number | null;
   };
   timestamp: string;


### PR DESCRIPTION
## 개요

PVP 배틀 진행 중 5초 간격으로 참가자별 현재 평가금액을 계산하고 STOMP RANK_UPDATE 메시지를 브로드캐스트합니다. 기존에 `BattleMessageType.RANK_UPDATE`가 enum에 정의만 되어 있고 실제 발행 로직이 없어 배틀 진행 중 실시간 순위가 전혀 갱신되지 않던 문제를 해결합니다.

## 변경 내용

- `BattleRankingScheduler.kt` 신규 생성 — 5초 간격으로 IN_PROGRESS 배틀 조회, 참가자별 `user.balance + Σ(openPositions.evaluatedValue(currentPrice))` 계산 후 RANK_UPDATE 브로드캐스트
- `BattleRepository.kt` — `findAllByStatus(status)` 쿼리 추가
- `PositionRepository.kt` — `findAllByUserIdInAndStatus()` 배치 조회 쿼리 추가
- `BattleRankingSchedulerTest.kt` — 단위 테스트 4개 추가
- `types/index.ts` — `BattleStompMessage.data.rankings` optional 타입 수정
- `useBattleStore.ts` — `updateRankings` 불필요한 이중 set 제거

## 관련 이슈

Close #22