### PR TITLE
feat: 바이낸스 WebSocket 시세 통합 #24

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
-    testImplementation("org.testcontainers:redis")
+    testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
     testImplementation("io.mockk:mockk:1.13.13")

--- a/backend/src/main/kotlin/com/coinbattle/domain/market/client/BinanceWebSocketClient.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/market/client/BinanceWebSocketClient.kt
@@ -1,0 +1,129 @@
+package com.coinbattle.domain.market.client
+
+import com.coinbattle.domain.market.dto.response.ChangeType
+import com.coinbattle.domain.market.dto.response.TickerResponse
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.market.service.TickerPubSubPublisher
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.socket.WebSocketMessage
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient
+import java.net.URI
+
+@Component
+class BinanceWebSocketClient(
+    private val tickerRedisRepository: TickerRedisRepository,
+    private val tickerPubSubPublisher: TickerPubSubPublisher,
+    private val objectMapper: ObjectMapper
+) : ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val wsClient = ReactorNettyWebSocketClient()
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    @Volatile
+    private var marketsRegistered = false
+
+    override fun run(args: ApplicationArguments) {
+        scope.launch { connectWithBackoff() }
+    }
+
+    private suspend fun connectWithBackoff() {
+        val delays = longArrayOf(1_000, 2_000, 4_000, 8_000, 16_000, 30_000)
+        var attempt = 0
+        while (true) {
+            runCatching { connect() }
+                .onFailure { log.warn("바이낸스 WebSocket 연결 실패 (attempt={}): {}", attempt + 1, it.message) }
+            val waitMs = delays[minOf(attempt, delays.size - 1)]
+            attempt++
+            delay(waitMs)
+        }
+    }
+
+    private suspend fun connect() {
+        marketsRegistered = false
+        log.info("바이낸스 WebSocket 연결 시작")
+        wsClient.execute(URI.create("wss://stream.binance.com:9443/ws/!miniTicker@arr")) { session ->
+            session.receive()
+                .map(WebSocketMessage::getPayloadAsText)
+                .doOnNext { handleMessage(it) }
+                .doOnError { log.warn("바이낸스 메시지 수신 오류: {}", it.message) }
+                .then()
+        }.block()
+    }
+
+    private fun handleMessage(raw: String) {
+        runCatching {
+            val root = objectMapper.readTree(raw)
+            if (!root.isArray) return
+
+            val markets = mutableListOf<String>()
+            root.forEach { node ->
+                val ticker = node.toTickerResponse() ?: return@forEach
+                markets.add(ticker.market)
+                tickerRedisRepository.save(ticker)
+                tickerPubSubPublisher.publish(ticker)
+            }
+
+            if (!marketsRegistered && markets.isNotEmpty()) {
+                tickerRedisRepository.saveMarkets(markets)
+                marketsRegistered = true
+            }
+        }.onFailure { log.debug("바이낸스 메시지 파싱 실패: {}", it.message) }
+    }
+
+    internal fun parseFirstTicker(raw: String): TickerResponse? {
+        val root = objectMapper.readTree(raw)
+        if (!root.isArray) return null
+        return root.firstOrNull()?.toTickerResponse()
+    }
+
+    internal fun symbolToMarket(symbol: String): String? {
+        val upper = symbol.uppercase()
+        val quote = listOf("USDT").firstOrNull { upper.endsWith(it) } ?: return null
+        val base = upper.removeSuffix(quote)
+        return if (base.isEmpty()) null else "$quote-$base"
+    }
+
+    private fun JsonNode.toTickerResponse(): TickerResponse? {
+        val symbol = this["s"]?.asText() ?: return null
+        val market = symbolToMarket(symbol) ?: return null
+
+        val closePrice = this["c"]?.asDouble() ?: return null
+        val openPrice = this["o"]?.asDouble() ?: return null
+        val highPrice = this["h"]?.asDouble() ?: return null
+        val lowPrice = this["l"]?.asDouble() ?: return null
+        val baseVolume = this["v"]?.asDouble() ?: return null
+        val quoteVolume = this["q"]?.asDouble() ?: return null
+        val timestamp = this["E"]?.asLong()
+
+        val changePrice = closePrice - openPrice
+        val changeRate = if (openPrice != 0.0) changePrice / openPrice else 0.0
+        val change = when {
+            changeRate > 0 -> ChangeType.RISE
+            changeRate < 0 -> ChangeType.FALL
+            else -> ChangeType.EVEN
+        }
+
+        return TickerResponse(
+            market = market,
+            tradePrice = closePrice,
+            changeRate = changeRate,
+            changePrice = changePrice,
+            change = change,
+            accTradeVolume24h = baseVolume,
+            accTradePrice24h = quoteVolume,
+            highPrice = highPrice,
+            lowPrice = lowPrice,
+            timestamp = timestamp
+        )
+    }
+}

--- a/backend/src/test/kotlin/com/coinbattle/domain/market/BinanceWebSocketClientTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/market/BinanceWebSocketClientTest.kt
@@ -1,0 +1,103 @@
+package com.coinbattle.domain.market
+
+import com.coinbattle.domain.market.client.BinanceWebSocketClient
+import com.coinbattle.domain.market.dto.response.ChangeType
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import io.mockk.junit5.MockKExtension
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.market.service.TickerPubSubPublisher
+
+@ExtendWith(MockKExtension::class)
+class BinanceWebSocketClientTest {
+
+    private lateinit var client: BinanceWebSocketClient
+
+    @BeforeEach
+    fun setUp() {
+        client = BinanceWebSocketClient(
+            tickerRedisRepository = mockk(relaxed = true),
+            tickerPubSubPublisher = mockk(relaxed = true),
+            objectMapper = ObjectMapper()
+        )
+    }
+
+    @Test
+    fun `BTCUSDT는 USDT-BTC로 변환된다`() {
+        val result = client.symbolToMarket("BTCUSDT")
+        assertThat(result).isEqualTo("USDT-BTC")
+    }
+
+    @Test
+    fun `ETHUSDT는 USDT-ETH로 변환된다`() {
+        val result = client.symbolToMarket("ETHUSDT")
+        assertThat(result).isEqualTo("USDT-ETH")
+    }
+
+    @Test
+    fun `1INCHUSDT는 USDT-1INCH로 변환된다`() {
+        val result = client.symbolToMarket("1INCHUSDT")
+        assertThat(result).isEqualTo("USDT-1INCH")
+    }
+
+    @Test
+    fun `USDT 외 quote 통화는 null을 반환한다`() {
+        val result = client.symbolToMarket("ETHBTC")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `빈 문자열은 null을 반환한다`() {
+        val result = client.symbolToMarket("")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `USDT만 있는 심볼은 base가 없으므로 null을 반환한다`() {
+        val result = client.symbolToMarket("USDT")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `openPrice가 0이면 changeRate는 0이고 ChangeType은 EVEN이다`() {
+        val raw = """[{
+            "s":"BTCUSDT",
+            "c":"50000.0","o":"0.0","h":"51000.0","l":"49000.0",
+            "v":"100.0","q":"5000000.0","E":1700000000000
+        }]"""
+        val ticker = client.parseFirstTicker(raw)
+        assertThat(ticker).isNotNull
+        assertThat(ticker!!.changeRate).isEqualTo(0.0)
+        assertThat(ticker.change).isEqualTo(ChangeType.EVEN)
+    }
+
+    @Test
+    fun `closePrice가 openPrice보다 크면 ChangeType은 RISE이다`() {
+        val raw = """[{
+            "s":"ETHUSDT",
+            "c":"2100.0","o":"2000.0","h":"2200.0","l":"1900.0",
+            "v":"500.0","q":"1000000.0","E":1700000000000
+        }]"""
+        val ticker = client.parseFirstTicker(raw)
+        assertThat(ticker).isNotNull
+        assertThat(ticker!!.change).isEqualTo(ChangeType.RISE)
+        assertThat(ticker.changeRate).isGreaterThan(0.0)
+    }
+
+    @Test
+    fun `closePrice가 openPrice보다 작으면 ChangeType은 FALL이다`() {
+        val raw = """[{
+            "s":"ETHUSDT",
+            "c":"1900.0","o":"2000.0","h":"2200.0","l":"1800.0",
+            "v":"500.0","q":"1000000.0","E":1700000000000
+        }]"""
+        val ticker = client.parseFirstTicker(raw)
+        assertThat(ticker).isNotNull
+        assertThat(ticker!!.change).isEqualTo(ChangeType.FALL)
+        assertThat(ticker.changeRate).isLessThan(0.0)
+    }
+}

--- a/frontend/src/pages/BattleRoom.tsx
+++ b/frontend/src/pages/BattleRoom.tsx
@@ -294,14 +294,14 @@ function FinishedView({
           <div className="flex items-center gap-4">
             <div className="text-center">
               <p className="text-xs text-zinc-500 mb-0.5">수익률</p>
-              <p className={`text-xl font-bold font-mono ${winner.returnRate >= 0 ? 'text-[#2DD4BF]' : 'text-red-400'}`}>
+              <p className={`text-xl font-bold font-mono ${(winner.returnRate ?? 0) >= 0 ? 'text-[#2DD4BF]' : 'text-red-400'}`}>
                 {formatReturnRate(winner.returnRate)}
               </p>
             </div>
             <div className="text-center">
               <p className="text-xs text-zinc-500 mb-0.5">최종 평가</p>
               <p className="text-sm font-semibold text-white font-mono">
-                {formatMoney(winner.currentValuation)}원
+                {formatMoney(winner.currentValuation ?? 0)}원
               </p>
             </div>
           </div>

--- a/frontend/src/pages/MarketListPage.tsx
+++ b/frontend/src/pages/MarketListPage.tsx
@@ -5,8 +5,16 @@ import { useMarketTickers } from '../hooks/useMarketTickers';
 import { useTickerSubscription } from '../hooks/useTickerSubscription';
 import { useTickerStore, type Ticker } from '../store/tickerStore';
 
-function formatPrice(price: number): string {
-  return price.toLocaleString('ko-KR');
+type ExchangeFilter = 'ALL' | 'UPBIT' | 'BINANCE';
+
+function formatPrice(market: string, price: number): string {
+  if (market.startsWith('USDT-')) {
+    if (price >= 1) {
+      return `$${price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    }
+    return `$${price.toFixed(6)}`;
+  }
+  return `₩${price.toLocaleString('ko-KR')}`;
 }
 
 function formatRate(rate: number): string {
@@ -14,7 +22,12 @@ function formatRate(rate: number): string {
   return `${sign}${(rate * 100).toFixed(2)}%`;
 }
 
-function formatVolume(volume: number): string {
+function formatVolume(market: string, volume: number): string {
+  if (market.startsWith('USDT-')) {
+    if (volume >= 1_000_000_000) return `$${(volume / 1_000_000_000).toFixed(1)}B`;
+    if (volume >= 1_000_000) return `$${(volume / 1_000_000).toFixed(1)}M`;
+    return `$${volume.toLocaleString('en-US')}`;
+  }
   if (volume >= 1_000_000_000_000) return `${(volume / 1_000_000_000_000).toFixed(0)}조`;
   if (volume >= 100_000_000) return `${(volume / 100_000_000).toFixed(0)}억`;
   if (volume >= 10_000) return `${(volume / 10_000).toFixed(0)}만`;
@@ -22,7 +35,7 @@ function formatVolume(volume: number): string {
 }
 
 function getCoinSymbol(market: string): string {
-  return market.replace('KRW-', '');
+  return market.split('-')[1] ?? market;
 }
 
 function TickerRow({ ticker }: { ticker: Ticker }) {
@@ -53,6 +66,8 @@ function TickerRow({ ticker }: { ticker: Ticker }) {
       ? 'bg-red-500/10'
       : '';
 
+  const isUsdt = ticker.market.startsWith('USDT-');
+
   return (
     <motion.div
       onClick={() => navigate(`/coin/${ticker.market}`)}
@@ -65,16 +80,21 @@ function TickerRow({ ticker }: { ticker: Ticker }) {
         <div className="flex items-center gap-2">
           <span className="font-bold text-white text-sm">{getCoinSymbol(ticker.market)}</span>
           <span className="text-xs text-zinc-600">{ticker.market}</span>
+          {isUsdt && (
+            <span className="text-[10px] bg-yellow-500/15 text-yellow-400 px-1.5 py-0.5 rounded font-medium">
+              USDT
+            </span>
+          )}
         </div>
       </div>
       <div className={`text-right w-36 font-mono font-semibold text-sm ${changeColor}`}>
-        ₩{formatPrice(ticker.tradePrice)}
+        {formatPrice(ticker.market, ticker.tradePrice)}
       </div>
       <div className={`text-right w-24 font-mono text-sm ${changeColor}`}>
         {formatRate(ticker.changeRate)}
       </div>
       <div className="text-right w-28 text-zinc-500 font-mono text-xs hidden sm:block">
-        {formatVolume(ticker.accTradePrice24h)}
+        {formatVolume(ticker.market, ticker.accTradePrice24h)}
       </div>
     </motion.div>
   );
@@ -96,24 +116,40 @@ function SkeletonRow() {
 
 const PAGE_SIZE = 20;
 
+const EXCHANGE_TABS: { value: ExchangeFilter; label: string; badge: string | null }[] = [
+  { value: 'ALL', label: '전체', badge: null },
+  { value: 'UPBIT', label: '업비트', badge: 'KRW' },
+  { value: 'BINANCE', label: '바이낸스', badge: 'USDT' },
+];
+
 export function MarketListPage() {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
+  const [exchangeFilter, setExchangeFilter] = useState<ExchangeFilter>('ALL');
   const { isLoading, isError, refetch } = useMarketTickers();
   const tickers = useTickerStore((s) => s.tickers);
-  const markets = Array.from(tickers.keys());
 
-  useTickerSubscription(markets);
+  const filtered = Array.from(tickers.values())
+    .filter((t) => {
+      if (exchangeFilter === 'UPBIT') return t.market.startsWith('KRW-');
+      if (exchangeFilter === 'BINANCE') return t.market.startsWith('USDT-');
+      return true;
+    })
+    .filter((t) => getCoinSymbol(t.market).toLowerCase().includes(search.toLowerCase()));
 
-  const filtered = Array.from(tickers.values()).filter((t) =>
-    getCoinSymbol(t.market).toLowerCase().includes(search.toLowerCase())
-  );
   const sorted = [...filtered].sort((a, b) => b.accTradePrice24h - a.accTradePrice24h);
   const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
   const paginated = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
+  useTickerSubscription(paginated.map((t) => t.market));
+
   const handleSearch = (value: string) => {
     setSearch(value);
+    setPage(1);
+  };
+
+  const handleExchangeFilter = (value: ExchangeFilter) => {
+    setExchangeFilter(value);
     setPage(1);
   };
 
@@ -134,7 +170,39 @@ export function MarketListPage() {
       </header>
 
       <main className="max-w-2xl mx-auto">
-        <div className="px-4 py-3">
+        <div className="px-4 pt-3 pb-2">
+          <div className="flex items-center gap-1.5">
+            {EXCHANGE_TABS.map((tab) => (
+              <motion.button
+                key={tab.value}
+                onClick={() => handleExchangeFilter(tab.value)}
+                whileTap={{ scale: 0.96 }}
+                className={`flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  exchangeFilter === tab.value
+                    ? 'bg-orange-500 text-white'
+                    : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+                }`}
+              >
+                {tab.label}
+                {tab.badge && (
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded font-semibold ${
+                      exchangeFilter === tab.value
+                        ? 'bg-white/20 text-white'
+                        : tab.value === 'BINANCE'
+                        ? 'bg-yellow-500/15 text-yellow-400'
+                        : 'bg-[#2DD4BF]/15 text-[#2DD4BF]'
+                    }`}
+                  >
+                    {tab.badge}
+                  </span>
+                )}
+              </motion.button>
+            ))}
+          </div>
+        </div>
+
+        <div className="px-4 pb-3">
           <input
             type="text"
             placeholder="코인 검색..."
@@ -182,6 +250,12 @@ export function MarketListPage() {
         {!isLoading && !isError && sorted.length === 0 && search && (
           <p className="text-center py-20 text-zinc-600 text-sm">
             "{search}"에 대한 결과가 없습니다
+          </p>
+        )}
+
+        {!isLoading && !isError && sorted.length === 0 && !search && exchangeFilter !== 'ALL' && (
+          <p className="text-center py-20 text-zinc-600 text-sm">
+            {exchangeFilter === 'UPBIT' ? '업비트' : '바이낸스'} 마켓 시세를 불러오는 중입니다
           </p>
         )}
 


### PR DESCRIPTION
## 개요

업비트(KRW 200개+)만 수신하던 시세 파이프라인에 바이낸스 글로벌 마켓(USDT 800개+)을 추가한다.
`BinanceWebSocketClient`가 기존 Pub/Sub 파이프라인을 그대로 재사용하므로 하위 컴포넌트(`TickerPubSubPublisher`, `TickerPubSubSubscriber`, `TickerRedisRepository`) 수정 없이 업비트와 바이낸스 시세를 동시에 처리한다.

## 변경 내용

- `BinanceWebSocketClient.kt` 신규 생성 — `!miniTicker@arr` 단일 스트림으로 800개+ USDT 마켓 수신, 지수 백오프 재연결
- 마켓 코드 변환: `BTCUSDT` → `USDT-BTC` (`KRW-BTC` 패턴과 일치)
- `BinanceWebSocketClientTest.kt` — `symbolToMarket()` 및 ChangeType 분기 단위 테스트 9개
- `MarketListPage.tsx` — 거래소 필터 탭(전체/업비트/바이낸스), USDT 가격 `$` 포맷, STOMP 구독 최적화(현재 페이지 20개)

## 관련 이슈

Close #24