### PR TITLE
feat: 펀딩비 정산 스케줄러 구현 #26

### DIFF
--- a/backend/src/main/kotlin/com/coinbattle/common/config/AsyncConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/AsyncConfig.kt
@@ -3,11 +3,13 @@ package com.coinbattle.common.config
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 
 @Configuration
 @EnableAsync
+@EnableScheduling
 class AsyncConfig {
 
     @Bean(name = ["taskExecutor"])

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/service/FundingRateScheduler.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/service/FundingRateScheduler.kt
@@ -1,0 +1,21 @@
+package com.coinbattle.domain.order.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class FundingRateScheduler(
+    private val fundingRateService: FundingRateService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 0 0,8,16 * * *", zone = "UTC")
+    @Async("taskExecutor")
+    fun settleFundingRate() {
+        log.info("funding rate settlement started")
+        fundingRateService.settleAll()
+        log.info("funding rate settlement completed")
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/service/FundingRateService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/service/FundingRateService.kt
@@ -1,0 +1,54 @@
+package com.coinbattle.domain.order.service
+
+import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.order.entity.OrderDirection
+import com.coinbattle.domain.order.entity.PositionStatus
+import com.coinbattle.domain.order.repository.PositionRepository
+import com.coinbattle.domain.user.repository.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+
+@Service
+class FundingRateService(
+    private val positionRepository: PositionRepository,
+    private val tickerRedisRepository: TickerRedisRepository,
+    private val userRepository: UserRepository
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val fundingRate = BigDecimal("0.0001")
+
+    fun settleAll() {
+        val openPositions = positionRepository.findAllByStatus(PositionStatus.OPEN)
+        for (position in openPositions) {
+            runCatching { settle(position.id) }
+                .onFailure { log.error("funding settlement failed positionId={}", position.id, it) }
+        }
+    }
+
+    private fun settle(positionId: Long) {
+        val position = positionRepository.findById(positionId).orElse(null) ?: return
+        if (position.status != PositionStatus.OPEN) return
+
+        val currentPrice = tickerRedisRepository.findByMarket(position.ticker)?.tradePrice?.toLong()
+        if (currentPrice == null) {
+            log.warn("funding skip: no price positionId={} ticker={}", positionId, position.ticker)
+            return
+        }
+
+        val positionValue = position.quantity.multiply(BigDecimal(currentPrice))
+        val fundingFee = positionValue.multiply(fundingRate).toLong()
+
+        val user = userRepository.findById(position.userId).orElse(null) ?: return
+        when (position.direction) {
+            OrderDirection.LONG -> user.balance = (user.balance - fundingFee).coerceAtLeast(0L)
+            OrderDirection.SHORT -> user.balance += fundingFee
+        }
+        userRepository.save(user)
+
+        log.info(
+            "funding settled positionId={} userId={} direction={} fee={}",
+            positionId, position.userId, position.direction, fundingFee
+        )
+    }
+}


### PR DESCRIPTION
## 개요

LONG/SHORT 포지션 보유 시 8시간마다 바이낸스 기준 펀딩비(0.01%)를 사용자 잔고에서 차감/지급한다. 실제 선물 거래의 펀딩비 메커니즘을 시뮬레이션하여 게임의 현실감을 높인다.

## 변경 내용

- `FundingRateService.kt` 생성 — OPEN 포지션 전체 조회 후 펀딩비 계산 및 잔고 갱신 (부분 실패 허용)
- `FundingRateScheduler.kt` 생성 — `@Scheduled(cron = "0 0 0,8,16 * * *", zone = "UTC")` + `@Async("taskExecutor")` 8시간 주기
- `AsyncConfig.kt` — `@EnableScheduling` 추가 (기존 누락)

## 관련 이슈

Close #26