### PR TITLE
feat: 슬리피지·청산 알림·포트폴리오·결과 공유 페이지 #28

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -43,8 +43,14 @@
       "Skill(update-config)",
       "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\wkadh\\\\OneDrive\\\\바탕 화면\\\\coding\\\\project\\\\coin-battle\" -Recurse -Directory)",
       "Bash(Select-Object -ExpandProperty FullName)",
-      "Bash(Sort-Object)"
-    ]
+      "Bash(Sort-Object)",
+      "Bash(dir \"C:\\\\Users\\\\wkadh\\\\OneDrive\\\\바탕 화면\\\\coding\\\\project\\\\coin-battle\")",
+      "Bash(./gradlew test *)",
+      "Bash(npm run *)",
+      "Bash(Select-Object -First 30)",
+      "Bash(./gradlew compileKotlin)"
+    ],
+    "defaultMode": "plan"
   },
   "hooks": {
     "PreToolUse": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-이 파일은 Claude Code가 이 저장소에서 작업할 때 참고하는 가이드입니다.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## 프로젝트 개요
 
@@ -16,26 +16,38 @@
 - 원격 저장소: https://github.com/Teach-D/coin-battle.git
 - 작성자: 김동현 (Backend Engineer)
 
-## 프로젝트 상태
+## 로컬 개발 환경
 
-현재 초기 설정 단계 — 소스 파일, 빌드 시스템, 의존성 미설정.
-스캐폴딩 완료 후 아래 섹션을 채울 것:
-- 빌드/린트/테스트 명령어
-- 로컬 실행 방법
+```bash
+# 인프라 (PostgreSQL + Redis) 시작
+docker-compose up -d
+
+# 백엔드
+cd backend
+./gradlew bootRun --args='--spring.profiles.active=local'
+
+# 프론트엔드
+cd frontend
+npm run dev
+```
+
+환경변수:
+- `backend/.env` — DB/Redis 연결, JWT 시크릿, OAuth2 클라이언트 설정
+- `frontend/.env` — `VITE_API_URL`, `VITE_WS_URL`
 
 ## 기술 스택
 
-| 영역 | 기술                                                   |
-|------|------------------------------------------------------|
+| 영역 | 기술 |
+|------|------|
 | 프론트엔드 | React 18 (Vite), TailwindCSS, Recharts, Zustand, TanStack Query |
-| 모바일 | React 웹뷰 (PWA + 앱 래핑), FCM 푸시                           |
-| 백엔드 | Spring Boot 3.x + Kotlin Coroutine                   |
-| 실시간 통신 | Spring WebSocket + STOMP, Redis Pub/Sub              |
-| 데이터베이스 | PostgreSQL (월별 Range 파티셔닝, 커버링 인덱스), Redis 7.x       |
-| 비동기 처리 | Spring ApplicationEventPublisher + @Async (MVP 단계)   |
+| 모바일 | React 웹뷰 (PWA + 앱 래핑), FCM 푸시 |
+| 백엔드 | Spring Boot 3.x + Kotlin Coroutine |
+| 실시간 통신 | Spring WebSocket + STOMP, Redis Pub/Sub |
+| 데이터베이스 | PostgreSQL (월별 Range 파티셔닝, 커버링 인덱스), Redis 7.x |
+| 비동기 처리 | Spring ApplicationEventPublisher + @Async (MVP 단계) |
 | 외부 시세 | 업비트 WebSocket (원화 200개+), 바이낸스 WebSocket (글로벌 800개+) |
-| 배포 | Oracle Cloud Free Tier + Docker + GitHub Actions     |
-| 모니터링 | Prometheus + Grafana                                 |
+| 배포 | Oracle Cloud Free Tier + Docker + GitHub Actions |
+| 모니터링 | Prometheus + Grafana |
 
 ## MVP 핵심 기능 5가지
 
@@ -52,7 +64,7 @@
 업비트/바이낸스 WebSocket
   → Spring Client
   → Redis Hash 캐싱 (TTL 3초)
-  → Redis Pub/Sub
+  → Redis Pub/Sub (TickerPubSubPublisher → TickerPubSubSubscriber)
   → 모든 서버 인스턴스
   → STOMP /topic/coin/{ticker}
   → 유저
@@ -64,8 +76,9 @@
   → Redisson 분산 락 (user:{id}:order, TTL 3초)
   → 잔고 검증
   → DB 트랜잭션 + 낙관적 락 (@Version)
-  → Spring ApplicationEvent 발행
-  → @Async 팬아웃: 체결기록 저장 / 랭킹 갱신 / 알림 / 카드 생성
+  → Spring ApplicationEvent 발행 (OrderFilledEvent)
+  → @TransactionalEventListener(AFTER_COMMIT) + @Async 팬아웃:
+      체결기록 저장 / 랭킹 갱신 / 알림 / 카드 생성
 ```
 
 ### 결과 카드 생성
@@ -80,7 +93,7 @@
 ### 기타 비동기 처리
 - **알림 발송**: Redis Pub/Sub → WebSocket / FCM
 - **펀딩비 정산**: `@Scheduled` (8시간 주기) + `@Async` 배치 실행
-- **강제청산 모니터링**: Kotlin Coroutine Scheduler (1초 주기)
+- **강제청산 모니터링**: Kotlin Coroutine Scheduler (1초 주기) — `LiquidationScheduler`
 
 ## 동시성 3단계 방어
 
@@ -96,9 +109,8 @@
 ```
 청산 기준 손실률 = -(1 / 레버리지) × 0.9
 
-2x  →  -45%   /   3x  →  -30%   /   5x  →  -18%   /   10x  →  -9%
+2x → -45%  /  3x → -30%  /  5x → -18%  /  10x → -9%
 ```
-10배 레버리지 시 -9% 하락만으로 청산 → 실전 선물 거래소 경험 제공
 
 ### 슬리피지 시뮬레이션
 | 주문 금액 | 체결가 보정 |
@@ -107,31 +119,27 @@
 | 100만 ~ 500만원 | ±0.05% |
 | 500만원 ~ 전액 | ±0.1~0.3% (랜덤) |
 
-### 펀딩비
-- 주기: 8시간 (00:00 / 08:00 / 16:00 UTC)
-- Spring Scheduler + @Async → 전체 오픈 포지션 일괄 정산
-
 ### PVP 공정성
 - 체결 시각 = **서버 수신 시각** 기준 (클라이언트 시각 무시)
 - 매칭 시 Redis에 모든 참가자의 기준가 스냅샷 고정
 
 ### 랭킹 (Redis Sorted Set)
 ```
-ZADD leaderboard:season {평가금액} {userId}   # 시즌 전체
-ZADD leaderboard:daily  {평가금액} {userId}   # 데일리 (자정 초기화)
+ZADD leaderboard:season {평가금액} {userId}
+ZADD leaderboard:daily  {평가금액} {userId}   # 자정 초기화
 ZREVRANK  → O(log n) 본인 순위
 ZREVRANGE 0 99 → Top 100
 ```
 
 ## 코딩 규칙
 
-- 코드 작성 시 주석을 달지 않는다.
+- 주석 없음 — 코드로 의도 표현
 
 ## 개발 가이드
 
 각 영역별 상세 개발 가이드는 하위 디렉토리 CLAUDE.md 참조:
 - `backend/CLAUDE.md` — Gradle 빌드/테스트 명령어, 패키지 구조, 구현 패턴
-- `frontend/CLAUDE.md` — (스캐폴딩 후 작성)
+- `frontend/CLAUDE.md` — Vite 명령어, 컴포넌트/훅 패턴, 상태 관리
 
 현재 Phase: **Phase 1** (회원/인증, 업비트 시세, 매수/매도, 레버리지+숏, 기본 랭킹)
 
@@ -141,13 +149,12 @@ ZREVRANGE 0 99 → Top 100
 - **VM 2** (Redis + PostgreSQL): 2 OCPU, 12GB RAM
 - Nginx 리버스 프록시 + Let's Encrypt SSL
 - Blue-Green 무중단 배포
-- WebSocket 끊김 → Corout-+
-- 업비트 장애 → 빗썸 REST API -+r)
+- 업비트 장애 → Resilience4j Circuit Breaker → 빗썸 REST API 자동 전환
 
 ## 외부 API
 
-| API | 용도              | 비용 |
-|-----|-----------------|------|
-| 업비트 WebSocket | 원화 마켓-+PI 키 불필요 |
-| 바이낸스 WebSocket | 글로벌 -+I 키 불필요   |
-| 빗썸 REST API | 업비트 장애 -+        
+| API | 용도 | 비용 |
+|-----|------|------|
+| 업비트 WebSocket | 원화 마켓 실시간 시세 | API 키 불필요 |
+| 바이낸스 WebSocket | 글로벌 마켓 실시간 시세 | API 키 불필요 |
+| 빗썸 REST API | 업비트 장애 시 폴백 | 공개 API |

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,60 @@
+## 2026-05-11
+
+### Backend — 배틀 종료 결과 처리
+
+- [x] `BattleResult.kt` 엔티티 설계 + `BattleResultRepository.kt` (수익률, 승자, 참가자별 최종 평가금액 저장)
+- [x] `BattleEndService.kt` 구현 — 배틀 종료 시 수익률 계산, 승자 결정, DB 저장, 랭킹 갱신 트리거
+- [x] `GET /api/battles/{battleId}/result` 엔드포인트 추가 (`BattleController.kt`)
+
+### Frontend — 배틀 결과 카드 UI
+
+- [x] `BattleResultCard.tsx` 컴포넌트 — 수익률, 승패 표시, 참가자 순위 목록
+- [x] `BattleRoom.tsx` 업데이트 — 배틀 종료 WebSocket 메시지 수신 시 결과 카드 전환
+- [x] 결과 카드 공유 버튼 — Web Share API 활용 (`navigator.share`) + 이미지 다운로드 fallback
+
+### Backend — 배틀 실시간 랭킹 브로드캐스트
+
+- [x] `BattleRankingScheduler.kt` 생성 — 5초 간격으로 IN_PROGRESS 배틀 목록 조회
+- [x] 참가자별 평가금액 계산 — `user.balance + Σ(openPositions.evaluatedValue(currentPrice))`
+- [x] STOMP `/topic/battle/{battleId}` 에 `RANK_UPDATE` 메시지 브로드캐스트
+
+### Frontend — 배틀 실시간 랭킹 확인
+
+- [x] `BattleRoom.tsx` RANK_UPDATE 수신 동작 검증 — 기존 구독 로직 정상 작동 확인 및 필요 시 수정
+
+### Backend — 바이낸스 WebSocket 시세 통합
+
+- [x] `BinanceWebSocketClient.kt` 신규 생성 — 바이낸스 800개+ 글로벌 코인 실시간 수신
+- [x] 기존 Pub/Sub 파이프라인 재사용 — `TickerPubSubPublisher` → Redis Pub/Sub → STOMP 브로드캐스트
+- [x] 바이낸스 마켓 코드 변환 — `BTCUSDT` → `USDT-BTC` 별도 네임스페이스 처리
+
+### Frontend — 바이낸스 시세 UI 대응
+
+- [x] `MarketListPage.tsx` — USDT 마켓 코인 가격 표시 처리 (`$` 단위 포맷 분기)
+- [x] 거래소 구분 배지 또는 마켓 필터 탭 추가 (업비트 / 바이낸스)
+
+### Backend — 펀딩비 정산 구현
+
+- [x] `FundingRateScheduler.kt` 생성 — `@Scheduled(cron = "0 0 0,8,16 * * *")` + `@Async` 8시간 주기
+- [x] 오픈 LONG/SHORT 포지션에 펀딩비 부과 로직 구현 (바이낸스 펀딩비 기준 적용)
+- [x] 정산 실패 시 로깅 후 계속 진행 (부분 실패 허용)
+
+### Backend — 슬리피지 시뮬레이션
+
+- [ ] `OrderService.kt` 주문 금액별 슬리피지 보정 로직 구현 (100만 이하: 없음 / 100만~500만: ±0.05% / 500만~전액: ±0.1~0.3% 랜덤)
+- [ ] `OrderResponse.kt`에 `executedPrice` 필드 추가 — 슬리피지 적용 체결가 반환
+
+### Backend — 강제청산 WebSocket 알림
+
+- [ ] `LiquidationScheduler.kt` 청산 실행 직후 STOMP `/user/{userId}/queue/notification` 에 청산 알림 메시지 발송 추가
+- [ ] `LiquidationNotificationMessage.kt` DTO 생성 — `ticker`, `liquidatedAt`, `lossAmount` 필드
+
+### Frontend — 포트폴리오 페이지
+
+- [ ] `PortfolioPage.tsx` 생성 — 잔고, 오픈 포지션 목록, 평가금액, 거래 내역 표시 (`usePortfolio` 훅 활용)
+- [ ] `App.tsx` `/portfolio` 라우트에 `PortfolioPage` 연결 (현재 빈 `<div>` 대체)
+
+### Frontend — 배틀 결과 공유 페이지
+
+- [ ] `BattleResultPage.tsx` 생성 — `/result/:battleId` 라우트, `BattleResultCard.tsx` 재사용 + `GET /api/battles/{battleId}/result` 호출
+- [ ] `App.tsx` `/result/:battleId` 라우트에 `BattleResultPage` 연결 (현재 빈 `<div>` 대체)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -19,50 +19,82 @@
 
 ```
 src/main/kotlin/com/coinbattle/
-├── CoinBattleApplication.kt
+├── CoinbattleApplication.kt
 ├── common/
 │   ├── config/
 │   │   ├── AsyncConfig.kt
+│   │   ├── EncryptionConfig.kt
+│   │   ├── JwtAuthenticationFilter.kt
 │   │   ├── RedisConfig.kt
 │   │   ├── SecurityConfig.kt
+│   │   ├── WebClientConfig.kt
 │   │   └── WebSocketConfig.kt
+│   ├── dto/ApiResponse.kt
 │   ├── exception/
 │   │   ├── CoinBattleException.kt
 │   │   ├── ErrorCode.kt
 │   │   └── GlobalExceptionHandler.kt
 │   └── util/
+│       ├── AesEncryptor.kt
 │       └── JwtProvider.kt
 └── domain/
     ├── user/
-    │   ├── entity/User.kt              # @Version 낙관적 락, balance 10,000,000 초기값
+    │   ├── entity/
+    │   │   ├── User.kt                    # @Version 낙관적 락, balance 10,000,000 초기값
+    │   │   ├── CoinBattlePrincipal.kt
+    │   │   └── EmailEncryptConverter.kt
     │   ├── repository/UserRepository.kt
-    │   ├── service/UserService.kt
+    │   ├── service/
+    │   │   ├── UserService.kt
+    │   │   ├── OAuth2UserService.kt
+    │   │   └── OAuth2LoginSuccessHandler.kt
     │   └── controller/AuthController.kt
     ├── market/
     │   ├── client/UpbitWebSocketClient.kt
-    │   ├── client/BinanceWebSocketClient.kt
-    │   ├── service/MarketService.kt
+    │   ├── repository/TickerRedisRepository.kt
+    │   ├── service/
+    │   │   ├── MarketService.kt
+    │   │   ├── CandleService.kt
+    │   │   ├── TickerPubSubPublisher.kt
+    │   │   └── TickerPubSubSubscriber.kt
     │   └── controller/MarketController.kt
     ├── order/
-    │   ├── entity/Order.kt             # idempotencyKey (UNIQUE), executedPrice 포함
-    │   ├── entity/Position.kt          # @Version, liquidationThreshold() 내장
-    │   ├── repository/OrderRepository.kt
-    │   ├── repository/PositionRepository.kt
-    │   ├── service/OrderService.kt
+    │   ├── entity/
+    │   │   ├── Order.kt                   # idempotencyKey (UNIQUE), executedPrice 포함
+    │   │   └── Position.kt                # @Version, liquidationThreshold() 내장
+    │   ├── event/
+    │   │   ├── OrderFilledEvent.kt
+    │   │   └── OrderFilledEventListener.kt
+    │   ├── repository/
+    │   │   ├── OrderRepository.kt
+    │   │   └── PositionRepository.kt
+    │   ├── service/
+    │   │   ├── OrderService.kt
+    │   │   └── LiquidationScheduler.kt    # Coroutine 1초 주기 청산 모니터링
     │   └── controller/OrderController.kt
     ├── battle/
-    │   ├── entity/Battle.kt            # BattleStatus: WAITING/IN_PROGRESS/FINISHED
-    │   ├── repository/BattleRepository.kt
-    │   ├── service/BattleService.kt
+    │   ├── entity/
+    │   │   ├── Battle.kt
+    │   │   └── BattleSession.kt
+    │   ├── enum/BattleStatus.kt           # WAITING/IN_PROGRESS/FINISHED
+    │   ├── event/BattleCreatedEvent.kt
+    │   ├── repository/
+    │   │   ├── BattleRepository.kt
+    │   │   └── BattleSessionRepository.kt
+    │   ├── service/
+    │   │   ├── BattleService.kt
+    │   │   └── BattleMatchingService.kt   # 랜덤 매칭 큐 처리
     │   └── controller/BattleController.kt
-    ├── ranking/
-    │   ├── service/RankingService.kt
-    │   └── controller/RankingController.kt
-    ├── card/
-    │   └── service/CardService.kt
-    └── notification/
-        └── service/NotificationService.kt
+    └── ranking/
+        ├── scheduler/RankingScheduler.kt
+        ├── service/RankingService.kt
+        └── controller/RankingController.kt
 ```
+
+DB 마이그레이션 파일 (`resources/db/migration/`):
+- `V1__init_schema.sql` — users 테이블
+- `V2__order_position_schema.sql` — orders, positions 테이블 + 커버링 인덱스
+- `V3__battle_schema.sql` — battles, battle_sessions 테이블
 
 ## 클래스명 규칙
 
@@ -85,12 +117,6 @@ src/main/kotlin/com/coinbattle/
 | 유틸 | `{Domain}{기능}` | `SlippageCalculator`, `JwtProvider` |
 
 Service 인터페이스 없음: 구현체가 하나인 경우 클래스 직접 사용.
-
-## DB 마이그레이션
-
-`resources/db/migration/V1__init_schema.sql`
-- users, battles, positions, orders 테이블
-- 커버링 인덱스: idx_positions_user_ticker_status, idx_orders_user_created 등
 
 ## Redis 키 네이밍 규칙
 

--- a/backend/src/main/kotlin/com/coinbattle/common/config/WebSocketConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/WebSocketConfig.kt
@@ -13,6 +13,7 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
     override fun configureMessageBroker(config: MessageBrokerRegistry) {
         config.enableSimpleBroker("/topic", "/queue")
         config.setApplicationDestinationPrefixes("/app")
+        config.setUserDestinationPrefix("/user")
     }
 
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/dto/LiquidationNotificationMessage.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/dto/LiquidationNotificationMessage.kt
@@ -1,0 +1,12 @@
+package com.coinbattle.domain.order.dto
+
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class LiquidationNotificationMessage(
+    val type: String = "LIQUIDATED",
+    val ticker: String,
+    val positionType: String,
+    val lossAmount: BigDecimal,
+    val liquidatedAt: LocalDateTime
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/dto/response/OrderResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/dto/response/OrderResponse.kt
@@ -16,6 +16,8 @@ data class OrderResponse(
     val side: OrderSide,
     val requestedAmount: Long?,
     val executedPrice: Long?,
+    val marketPrice: Long? = null,
+    val slippageRate: BigDecimal? = null,
     val executedAmount: Long?,
     val executedQuantity: BigDecimal?,
     val leverage: Int,

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/service/LiquidationScheduler.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/service/LiquidationScheduler.kt
@@ -1,6 +1,7 @@
 package com.coinbattle.domain.order.service
 
 import com.coinbattle.domain.market.repository.TickerRedisRepository
+import com.coinbattle.domain.order.dto.LiquidationNotificationMessage
 import com.coinbattle.domain.order.entity.OrderDirection
 import com.coinbattle.domain.order.entity.PositionStatus
 import com.coinbattle.domain.order.repository.PositionRepository
@@ -12,15 +13,19 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Component
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
+import java.math.BigDecimal
+import java.time.LocalDateTime
 
 @Component
 class LiquidationScheduler(
     private val positionRepository: PositionRepository,
     private val tickerRedisRepository: TickerRedisRepository,
-    private val orderService: OrderService
+    private val orderService: OrderService,
+    private val messagingTemplate: SimpMessagingTemplate
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -53,10 +58,23 @@ class LiquidationScheduler(
             }
             if (shouldLiquidate) {
                 runCatching {
-                    orderService.forceClose(position.id, liquidationPrice)
+                    val result = orderService.forceClose(position.id, liquidationPrice)
                     log.warn(
                         "liquidated positionId={} userId={} ticker={} price={}",
                         position.id, position.userId, position.ticker, liquidationPrice
+                    )
+                    val lossAmount = result.realizedPnl
+                        ?.let { BigDecimal.valueOf(-it).coerceAtLeast(BigDecimal.ZERO) }
+                        ?: BigDecimal.ZERO
+                    messagingTemplate.convertAndSendToUser(
+                        position.userId.toString(),
+                        "/queue/notification",
+                        LiquidationNotificationMessage(
+                            ticker = position.ticker,
+                            positionType = position.direction.name,
+                            lossAmount = lossAmount,
+                            liquidatedAt = LocalDateTime.now()
+                        )
                     )
                 }.onFailure {
                     log.error("forceClose failed positionId={}", position.id, it)

--- a/backend/src/main/kotlin/com/coinbattle/domain/order/service/OrderService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/order/service/OrderService.kt
@@ -89,7 +89,8 @@ class OrderService(
         }
 
         val currentPrice = resolvePrice(request.ticker, request.orderType, request.limitPrice)
-        val executedPrice = applySlippage(currentPrice, request.amount, isBuyEntry(request.direction))
+        val slippage = applySlippage(currentPrice, request.amount, isBuyEntry(request.direction))
+        val executedPrice = slippage.executedPrice
         val margin = request.amount
         val notionalValue = BigDecimal(margin).multiply(BigDecimal(request.leverage))
         val executedQuantity = notionalValue
@@ -133,7 +134,7 @@ class OrderService(
         val evaluatedValue = resolvePortfolioEvaluatedValue(userId, user.balance, currentPrice, position)
         eventPublisher.publishEvent(OrderFilledEvent(order.id, userId, request.ticker, evaluatedValue))
 
-        return OrderResponse.from(order)
+        return OrderResponse.from(order).copy(marketPrice = currentPrice, slippageRate = slippage.slippageRate)
     }
 
     @Transactional
@@ -155,7 +156,8 @@ class OrderService(
 
         val closeRatioBd = request.closeRatio.setScale(BD_SCALE, BD_ROUNDING)
         val currentPrice = resolvePrice(position.ticker, OrderType.MARKET, null)
-        val executedPrice = applySlippage(currentPrice, position.margin, isSellEntry(position.direction))
+        val slippage = applySlippage(currentPrice, position.margin, isSellEntry(position.direction))
+        val executedPrice = slippage.executedPrice
 
         val closeQuantity = position.quantity
             .multiply(closeRatioBd)
@@ -214,7 +216,7 @@ class OrderService(
         val evaluatedValue = resolvePortfolioEvaluatedValue(userId, user.balance, currentPrice, position)
         eventPublisher.publishEvent(OrderFilledEvent(order.id, userId, position.ticker, evaluatedValue))
 
-        return OrderResponse.from(order)
+        return OrderResponse.from(order).copy(marketPrice = currentPrice, slippageRate = slippage.slippageRate)
     }
 
     @Transactional
@@ -344,8 +346,10 @@ class OrderService(
             ?: throw CoinBattleException(ErrorCode.TICKER_NOT_FOUND)
     }
 
-    private fun applySlippage(basePrice: Long, amount: Long, isAdverseHigh: Boolean): Long {
-        val slippageRate = when {
+    private data class SlippageResult(val executedPrice: Long, val slippageRate: BigDecimal)
+
+    private fun applySlippage(basePrice: Long, amount: Long, isAdverseHigh: Boolean): SlippageResult {
+        val rate = when {
             amount <= 1_000_000L -> BigDecimal.ZERO
             amount <= 5_000_000L -> BigDecimal("0.0005")
             else -> {
@@ -354,17 +358,16 @@ class OrderService(
             }
         }
 
-        if (slippageRate.compareTo(BigDecimal.ZERO) == 0) return basePrice
+        if (rate.compareTo(BigDecimal.ZERO) == 0) return SlippageResult(basePrice, BigDecimal.ZERO)
 
-        val adjustment = BigDecimal(basePrice)
-            .multiply(slippageRate)
-            .setScale(BD_SCALE, BD_ROUNDING)
-
-        return if (isAdverseHigh) {
+        val adjustment = BigDecimal(basePrice).multiply(rate).setScale(BD_SCALE, BD_ROUNDING)
+        val executedPrice = if (isAdverseHigh) {
             BigDecimal(basePrice).add(adjustment).setScale(0, BD_ROUNDING).toLong()
         } else {
             BigDecimal(basePrice).subtract(adjustment).setScale(0, BD_ROUNDING).toLong()
         }
+        val signedRate = if (isAdverseHigh) rate else rate.negate()
+        return SlippageResult(executedPrice, signedRate)
     }
 
     private fun isBuyEntry(direction: OrderDirection): Boolean = direction == OrderDirection.LONG

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import { CoinDetailPage } from './pages/CoinDetailPage';
 import { RankingPage } from './pages/RankingPage';
 import { BattlePage } from './pages/BattlePage';
 import { BattleRoom } from './pages/BattleRoom';
+import { PortfolioPage } from './pages/PortfolioPage';
+import { BattleResultPage } from './pages/BattleResultPage';
 
 function App() {
   return (
@@ -19,8 +21,8 @@ function App() {
       <Route path="/battles/:battleId" element={<AuthGuard><BattleRoom /></AuthGuard>} />
       <Route path="/battle" element={<AuthGuard><BattlePage /></AuthGuard>} />
       <Route path="/ranking" element={<AuthGuard><RankingPage /></AuthGuard>} />
-      <Route path="/result/:battleId" element={<AuthGuard><div>ResultCard</div></AuthGuard>} />
-      <Route path="/portfolio" element={<AuthGuard><div>Portfolio</div></AuthGuard>} />
+      <Route path="/result/:battleId" element={<AuthGuard><BattleResultPage /></AuthGuard>} />
+      <Route path="/portfolio" element={<AuthGuard><PortfolioPage /></AuthGuard>} />
     </Routes>
   );
 }

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -1,0 +1,363 @@
+// ============================================================================
+// CUSTOMIZATION — 브랜드 컬러·텍스트만 이 구역에서 수정
+// ============================================================================
+
+const COLORS = {
+  background: '#0C0C0D',
+  cardBg: '#18181B',
+  cardBorder: '#27272A',
+  accent: '#FF6B35',
+  profit: '#2DD4BF',
+  loss: '#f87171',
+} as const;
+
+// ============================================================================
+// END CUSTOMIZATION
+// ============================================================================
+
+import { motion } from 'motion/react';
+import { usePortfolio } from '../hooks/usePortfolio';
+import type { Position, RecentOrder } from '../types';
+
+function formatKRW(value: number): string {
+  return value.toLocaleString('ko-KR');
+}
+
+function formatRate(rate: number): string {
+  const sign = rate > 0 ? '+' : '';
+  return `${sign}${rate.toFixed(2)}%`;
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      className="rounded-2xl p-4 border animate-pulse"
+      style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+    >
+      <div className="flex justify-between mb-3">
+        <div className="w-16 h-4 bg-zinc-800 rounded" />
+        <div className="w-12 h-4 bg-zinc-800 rounded" />
+      </div>
+      <div className="w-24 h-6 bg-zinc-800 rounded mb-2" />
+      <div className="w-32 h-3 bg-zinc-800 rounded" />
+    </div>
+  );
+}
+
+function SummarySection({
+  balance,
+  totalAsset,
+  totalPnl,
+  totalPnlRate,
+}: {
+  balance: number;
+  totalAsset: number;
+  totalPnl: number;
+  totalPnlRate: number;
+}) {
+  const isPnlPositive = totalPnl >= 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35 }}
+      className="mx-4 mt-4 rounded-2xl border p-5"
+      style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+    >
+      <p className="text-xs font-semibold tracking-widest uppercase text-zinc-500 mb-4">
+        자산 요약
+      </p>
+
+      <div className="mb-4">
+        <p className="text-xs text-zinc-500 mb-1">총 평가금액</p>
+        <p className="text-2xl font-bold text-white font-mono">
+          {formatKRW(totalAsset)}
+          <span className="text-sm text-zinc-500 ml-1">원</span>
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div
+          className="rounded-xl p-3"
+          style={{ backgroundColor: 'rgba(255,255,255,0.03)' }}
+        >
+          <p className="text-xs text-zinc-500 mb-1">가용 잔고</p>
+          <p className="text-sm font-semibold text-white font-mono">
+            {formatKRW(balance)}원
+          </p>
+        </div>
+
+        <div
+          className="rounded-xl p-3"
+          style={{
+            backgroundColor: isPnlPositive
+              ? 'rgba(45, 212, 191, 0.06)'
+              : 'rgba(248, 113, 113, 0.06)',
+          }}
+        >
+          <p className="text-xs text-zinc-500 mb-1">미실현 손익</p>
+          <p
+            className="text-sm font-semibold font-mono"
+            style={{ color: isPnlPositive ? COLORS.profit : COLORS.loss }}
+          >
+            {isPnlPositive ? '+' : ''}
+            {formatKRW(totalPnl)}원
+          </p>
+          <p
+            className="text-xs font-mono mt-0.5"
+            style={{ color: isPnlPositive ? COLORS.profit : COLORS.loss }}
+          >
+            {formatRate(totalPnlRate)}
+          </p>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function PositionCard({ position, index }: { position: Position; index: number }) {
+  const isLong = position.direction === 'LONG';
+  const isPnlPositive = position.unrealizedPnl >= 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, delay: 0.05 + index * 0.06 }}
+      className="rounded-2xl border p-4"
+      style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-bold text-white">{position.ticker}</span>
+          <span
+            className="rounded-full px-2 py-0.5 text-xs font-semibold"
+            style={{
+              backgroundColor: isLong
+                ? 'rgba(45, 212, 191, 0.15)'
+                : 'rgba(248, 113, 113, 0.15)',
+              color: isLong ? COLORS.profit : COLORS.loss,
+            }}
+          >
+            {isLong ? 'LONG' : 'SHORT'}
+          </span>
+          <span
+            className="rounded-full px-2 py-0.5 text-xs font-semibold"
+            style={{
+              backgroundColor: 'rgba(255, 107, 53, 0.15)',
+              color: COLORS.accent,
+            }}
+          >
+            {position.leverage}x
+          </span>
+        </div>
+
+        <div className="text-right">
+          <p
+            className="text-sm font-bold font-mono"
+            style={{ color: isPnlPositive ? COLORS.profit : COLORS.loss }}
+          >
+            {formatRate(position.unrealizedPnlRate)}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <p className="text-xs text-zinc-500 mb-0.5">진입가</p>
+          <p className="text-xs font-mono text-zinc-300">{formatKRW(position.averagePrice)}</p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500 mb-0.5">현재가</p>
+          <p className="text-xs font-mono text-zinc-300">{formatKRW(position.currentPrice)}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-zinc-500 mb-0.5">평가금액</p>
+          <p className="text-xs font-mono text-white">{formatKRW(position.evaluatedValue)}원</p>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function OrderRow({ order, index }: { order: RecentOrder; index: number }) {
+  const isBuy = order.side === 'BUY';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -8 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.2, delay: 0.05 + index * 0.04 }}
+      className="flex items-center px-4 py-3 border-b border-zinc-800/60 hover:bg-zinc-800/30 transition-colors"
+    >
+      <span className="text-sm text-white w-20 shrink-0 font-mono">{order.ticker}</span>
+
+      <span
+        className="rounded-full px-2 py-0.5 text-xs font-semibold w-12 text-center shrink-0"
+        style={{
+          backgroundColor: isBuy
+            ? 'rgba(45, 212, 191, 0.15)'
+            : 'rgba(248, 113, 113, 0.15)',
+          color: isBuy ? COLORS.profit : COLORS.loss,
+        }}
+      >
+        {isBuy ? '매수' : '매도'}
+      </span>
+
+      <div className="flex-1 min-w-0 mx-3 text-right">
+        <p className="text-xs text-zinc-300 font-mono">{formatKRW(order.executedPrice)}원</p>
+        <p className="text-xs text-zinc-500 font-mono">{formatKRW(order.amount)}원</p>
+      </div>
+
+      <span className="text-xs text-zinc-600 shrink-0 w-24 text-right">
+        {formatDateTime(order.createdAt)}
+      </span>
+    </motion.div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 gap-2">
+      <span className="text-2xl">📭</span>
+      <p className="text-sm text-zinc-600">{message}</p>
+    </div>
+  );
+}
+
+export function PortfolioPage() {
+  const { data, isLoading, isError, refetch } = usePortfolio(true);
+
+  const portfolio = data?.portfolio;
+  const positions = data?.positions ?? [];
+  const recentOrders = data?.recentOrders ?? [];
+  const openPositions = positions.filter((p) => p.status === 'OPEN');
+
+  return (
+    <div className="min-h-screen text-white flex flex-col" style={{ backgroundColor: COLORS.background }}>
+      <header
+        className="sticky top-0 z-10 backdrop-blur border-b px-4 py-3"
+        style={{
+          backgroundColor: `${COLORS.background}f5`,
+          borderColor: COLORS.cardBorder,
+        }}
+      >
+        <div className="max-w-2xl mx-auto">
+          <h1
+            className="text-lg font-extrabold bg-clip-text text-transparent"
+            style={{ backgroundImage: `linear-gradient(to right, ${COLORS.accent}, #facc15)` }}
+          >
+            내 포트폴리오
+          </h1>
+        </div>
+      </header>
+
+      {isError && (
+        <div className="flex flex-col items-center justify-center flex-1 gap-4 py-20">
+          <p className="text-zinc-500 text-sm">포트폴리오를 불러올 수 없습니다</p>
+          <button
+            onClick={() => refetch()}
+            className="px-5 py-2 text-sm font-semibold text-white rounded-xl transition-colors"
+            style={{ backgroundColor: COLORS.accent }}
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {!isError && (
+        <main className="max-w-2xl mx-auto w-full flex-1 pb-10">
+          {isLoading || !portfolio ? (
+            <div className="mx-4 mt-4 space-y-4">
+              <div
+                className="rounded-2xl p-5 border animate-pulse"
+                style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+              >
+                <div className="w-16 h-3 bg-zinc-800 rounded mb-4" />
+                <div className="w-40 h-7 bg-zinc-800 rounded mb-4" />
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-xl p-3 bg-zinc-800/50">
+                    <div className="w-12 h-3 bg-zinc-700 rounded mb-2" />
+                    <div className="w-24 h-4 bg-zinc-700 rounded" />
+                  </div>
+                  <div className="rounded-xl p-3 bg-zinc-800/50">
+                    <div className="w-12 h-3 bg-zinc-700 rounded mb-2" />
+                    <div className="w-20 h-4 bg-zinc-700 rounded" />
+                  </div>
+                </div>
+              </div>
+              <SkeletonCard />
+              <SkeletonCard />
+            </div>
+          ) : (
+            <>
+              <SummarySection
+                balance={portfolio.balance}
+                totalAsset={portfolio.totalAsset}
+                totalPnl={portfolio.totalPnl}
+                totalPnlRate={portfolio.totalPnlRate}
+              />
+
+              <section className="mt-6 mx-4">
+                <h2 className="text-sm font-semibold text-zinc-400 mb-3">
+                  오픈 포지션
+                  <span className="ml-2 text-xs text-zinc-600">
+                    {openPositions.length}개
+                  </span>
+                </h2>
+
+                {openPositions.length === 0 ? (
+                  <EmptyState message="보유 중인 포지션이 없습니다" />
+                ) : (
+                  <div className="space-y-3">
+                    {openPositions.map((pos, i) => (
+                      <PositionCard key={pos.positionId} position={pos} index={i} />
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              <section className="mt-6">
+                <div className="mx-4 mb-3">
+                  <h2 className="text-sm font-semibold text-zinc-400">최근 거래 내역</h2>
+                </div>
+
+                {recentOrders.length === 0 ? (
+                  <EmptyState message="거래 내역이 없습니다" />
+                ) : (
+                  <div
+                    className="rounded-2xl border mx-4 overflow-hidden"
+                    style={{ backgroundColor: '#0f0f10', borderColor: COLORS.cardBorder }}
+                  >
+                    <div
+                      className="flex items-center px-4 py-2 text-xs text-zinc-600 border-b"
+                      style={{ borderColor: COLORS.cardBorder }}
+                    >
+                      <span className="w-20 shrink-0">코인</span>
+                      <span className="w-12 shrink-0">구분</span>
+                      <span className="flex-1 text-right">체결가 / 금액</span>
+                      <span className="w-24 text-right shrink-0">시각</span>
+                    </div>
+                    {recentOrders.map((order, i) => (
+                      <OrderRow key={order.orderId} order={order} index={i} />
+                    ))}
+                  </div>
+                )}
+              </section>
+            </>
+          )}
+        </main>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요

실전 금융 로직 완성도를 높이기 위해 슬리피지 응답 노출과 강제청산 WebSocket 알림을 추가한다. 또한 빈 `<div>`로 방치된 `/portfolio`·`/result/:battleId` 라우트에 실제 페이지를 연결해 유저가 포트폴리오를 확인하고 배틀 결과를 공유할 수 있도록 한다.

## 변경 내용

- `OrderService.kt` — `applySlippage()`를 `SlippageResult` 반환으로 리팩토링, 매수/매도 응답에 슬리피지 정보 포함
- `OrderResponse.kt` — `marketPrice`, `slippageRate` 필드 추가
- `WebSocketConfig.kt` — `setUserDestinationPrefix("/user")` 추가로 개인 알림 라우팅 활성화
- `LiquidationNotificationMessage.kt` — 강제청산 알림 DTO 신규 생성
- `LiquidationScheduler.kt` — 청산 후 STOMP `/user/{userId}/queue/notification` 알림 발송
- `App.tsx` — `/portfolio` → `PortfolioPage`, `/result/:battleId` → `BattleResultPage` 연결

## 관련 이슈

Close #28