### PR TITLE
feat: 사용자 프로필 API + 프로필 페이지 #30

### DIFF
--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleSessionRepository.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/repository/BattleSessionRepository.kt
@@ -46,4 +46,48 @@ interface BattleSessionRepository : JpaRepository<BattleSession, UUID> {
         @Param("participantId") participantId: Long,
         @Param("activeStatuses") activeStatuses: List<BattleStatus>
     ): Boolean
+
+    @Query("""
+        SELECT COUNT(bs) FROM BattleSession bs
+        WHERE bs.participantId = :userId
+        AND bs.battleId IN (
+            SELECT b.battleId FROM Battle b
+            WHERE b.status = com.coinbattle.domain.battle.enum.BattleStatus.FINISHED
+            AND b.winnerId = :userId
+        )
+    """)
+    fun countWins(@Param("userId") userId: Long): Long
+
+    @Query("""
+        SELECT COUNT(bs) FROM BattleSession bs
+        WHERE bs.participantId = :userId
+        AND bs.battleId IN (
+            SELECT b.battleId FROM Battle b
+            WHERE b.status = com.coinbattle.domain.battle.enum.BattleStatus.FINISHED
+            AND b.winnerId IS NOT NULL
+            AND b.winnerId <> :userId
+        )
+    """)
+    fun countLosses(@Param("userId") userId: Long): Long
+
+    @Query("""
+        SELECT COUNT(bs) FROM BattleSession bs
+        WHERE bs.participantId = :userId
+        AND bs.battleId IN (
+            SELECT b.battleId FROM Battle b
+            WHERE b.status = com.coinbattle.domain.battle.enum.BattleStatus.FINISHED
+            AND b.winnerId IS NULL
+        )
+    """)
+    fun countDraws(@Param("userId") userId: Long): Long
+
+    @Query("""
+        SELECT MAX((bs.finalValuation - b.seedMoney) * 100.0 / b.seedMoney)
+        FROM BattleSession bs, Battle b
+        WHERE bs.battleId = b.battleId
+        AND bs.participantId = :userId
+        AND b.status = com.coinbattle.domain.battle.enum.BattleStatus.FINISHED
+        AND bs.finalValuation IS NOT NULL
+    """)
+    fun findBestReturnRate(@Param("userId") userId: Long): Double?
 }

--- a/backend/src/main/kotlin/com/coinbattle/domain/user/controller/UserController.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/user/controller/UserController.kt
@@ -1,0 +1,40 @@
+package com.coinbattle.domain.user.controller
+
+import com.coinbattle.common.dto.ApiResponse
+import com.coinbattle.domain.user.dto.request.UpdateProfileRequest
+import com.coinbattle.domain.user.dto.response.UserProfileResponse
+import com.coinbattle.domain.user.dto.response.UserStatsResponse
+import com.coinbattle.domain.user.entity.CoinBattlePrincipal
+import com.coinbattle.domain.user.service.UserService
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/users")
+class UserController(private val userService: UserService) {
+
+    @GetMapping("/me")
+    fun getProfile(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal
+    ): ResponseEntity<ApiResponse<UserProfileResponse>> =
+        ResponseEntity.ok(ApiResponse.ok(userService.getProfile(principal.user.id)))
+
+    @PatchMapping("/me")
+    fun updateProfile(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal,
+        @Valid @RequestBody request: UpdateProfileRequest
+    ): ResponseEntity<ApiResponse<UserProfileResponse>> =
+        ResponseEntity.ok(ApiResponse.ok(userService.updateNickname(principal.user.id, request.nickname)))
+
+    @GetMapping("/me/stats")
+    fun getStats(
+        @AuthenticationPrincipal principal: CoinBattlePrincipal
+    ): ResponseEntity<ApiResponse<UserStatsResponse>> =
+        ResponseEntity.ok(ApiResponse.ok(userService.getUserStats(principal.user.id)))
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/user/dto/request/UpdateProfileRequest.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/user/dto/request/UpdateProfileRequest.kt
@@ -1,0 +1,10 @@
+package com.coinbattle.domain.user.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class UpdateProfileRequest(
+    @field:NotBlank
+    @field:Size(min = 2, max = 20)
+    val nickname: String
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/user/dto/response/UserProfileResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/user/dto/response/UserProfileResponse.kt
@@ -1,0 +1,8 @@
+package com.coinbattle.domain.user.dto.response
+
+data class UserProfileResponse(
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val email: String
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/user/dto/response/UserStatsResponse.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/user/dto/response/UserStatsResponse.kt
@@ -1,0 +1,10 @@
+package com.coinbattle.domain.user.dto.response
+
+data class UserStatsResponse(
+    val wins: Int,
+    val losses: Int,
+    val draws: Int,
+    val totalGames: Int,
+    val winRate: Double?,
+    val bestReturnRate: Double?
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/user/service/UserService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/user/service/UserService.kt
@@ -3,8 +3,11 @@ package com.coinbattle.domain.user.service
 import com.coinbattle.common.exception.CoinBattleException
 import com.coinbattle.common.exception.ErrorCode
 import com.coinbattle.common.util.JwtProvider
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
 import com.coinbattle.domain.user.dto.response.AccessTokenResponse
 import com.coinbattle.domain.user.dto.response.TokenResponse
+import com.coinbattle.domain.user.dto.response.UserProfileResponse
+import com.coinbattle.domain.user.dto.response.UserStatsResponse
 import com.coinbattle.domain.user.entity.AuthProvider
 import com.coinbattle.domain.user.entity.User
 import com.coinbattle.domain.user.repository.UserRepository
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class UserService(
     private val userRepository: UserRepository,
+    private val battleSessionRepository: BattleSessionRepository,
     private val jwtProvider: JwtProvider
 ) {
     fun findOrCreateSocialUser(
@@ -48,6 +52,39 @@ class UserService(
             .orElseThrow { CoinBattleException(ErrorCode.USER_NOT_FOUND) }
         return AccessTokenResponse(
             accessToken = jwtProvider.generateAccessToken(user.id, user.role.name)
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getProfile(userId: Long): UserProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { CoinBattleException(ErrorCode.USER_NOT_FOUND) }
+        return UserProfileResponse(user.id, user.nickname, user.profileImageUrl, user.email)
+    }
+
+    fun updateNickname(userId: Long, nickname: String): UserProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { CoinBattleException(ErrorCode.USER_NOT_FOUND) }
+        if (user.nickname != nickname && userRepository.existsByNickname(nickname)) {
+            throw CoinBattleException(ErrorCode.DUPLICATE_NICKNAME)
+        }
+        user.nickname = nickname
+        return UserProfileResponse(user.id, user.nickname, user.profileImageUrl, user.email)
+    }
+
+    @Transactional(readOnly = true)
+    fun getUserStats(userId: Long): UserStatsResponse {
+        val wins = battleSessionRepository.countWins(userId).toInt()
+        val losses = battleSessionRepository.countLosses(userId).toInt()
+        val draws = battleSessionRepository.countDraws(userId).toInt()
+        val total = wins + losses + draws
+        return UserStatsResponse(
+            wins = wins,
+            losses = losses,
+            draws = draws,
+            totalGames = total,
+            winRate = if (total > 0) wins.toDouble() / total * 100 else null,
+            bestReturnRate = battleSessionRepository.findBestReturnRate(userId)
         )
     }
 

--- a/backend/src/test/kotlin/com/coinbattle/domain/user/UserControllerTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/user/UserControllerTest.kt
@@ -1,0 +1,84 @@
+package com.coinbattle.domain.user
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.domain.user.controller.UserController
+import com.coinbattle.domain.user.dto.request.UpdateProfileRequest
+import com.coinbattle.domain.user.dto.response.UserProfileResponse
+import com.coinbattle.domain.user.dto.response.UserStatsResponse
+import com.coinbattle.domain.user.entity.AuthProvider
+import com.coinbattle.domain.user.entity.CoinBattlePrincipal
+import com.coinbattle.domain.user.entity.User
+import com.coinbattle.domain.user.service.UserService
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class UserControllerTest {
+
+    @MockK
+    lateinit var userService: UserService
+
+    lateinit var userController: UserController
+
+    @BeforeEach
+    fun setUp() {
+        userController = UserController(userService)
+    }
+
+    @Test
+    fun `PATCH_닉네임_중복_예외_전파`() {
+        val principal = createPrincipal(1L)
+        every { userService.updateNickname(1L, "dup") } throws
+            CoinBattleException(ErrorCode.DUPLICATE_NICKNAME)
+
+        assertThatThrownBy {
+            userController.updateProfile(principal, UpdateProfileRequest("dup"))
+        }.isInstanceOf(CoinBattleException::class.java)
+            .hasMessageContaining(ErrorCode.DUPLICATE_NICKNAME.message)
+    }
+
+    @Test
+    fun `PATCH_닉네임_성공_200_반환`() {
+        val principal = createPrincipal(1L)
+        val response = UserProfileResponse(1L, "newNick", null, "test@test.com")
+        every { userService.updateNickname(1L, "newNick") } returns response
+
+        val result = userController.updateProfile(principal, UpdateProfileRequest("newNick"))
+
+        assertThat(result.statusCode.value()).isEqualTo(200)
+        assertThat(result.body?.data?.nickname).isEqualTo("newNick")
+    }
+
+    @Test
+    fun `GET_stats_정상_반환`() {
+        val principal = createPrincipal(1L)
+        val stats = UserStatsResponse(3, 1, 0, 4, 75.0, 42.5)
+        every { userService.getUserStats(1L) } returns stats
+
+        val result = userController.getStats(principal)
+
+        assertThat(result.statusCode.value()).isEqualTo(200)
+        assertThat(result.body?.data?.wins).isEqualTo(3)
+        assertThat(result.body?.data?.winRate).isEqualTo(75.0)
+    }
+
+    private fun createPrincipal(userId: Long): CoinBattlePrincipal {
+        val user = User(
+            email = "user$userId@test.com",
+            nickname = "user$userId",
+            provider = AuthProvider.KAKAO,
+            providerId = "provider_$userId"
+        )
+        val field = User::class.java.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(user, userId)
+        return CoinBattlePrincipal(user)
+    }
+}

--- a/backend/src/test/kotlin/com/coinbattle/domain/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/user/UserServiceTest.kt
@@ -1,0 +1,116 @@
+package com.coinbattle.domain.user
+
+import com.coinbattle.common.exception.CoinBattleException
+import com.coinbattle.common.exception.ErrorCode
+import com.coinbattle.common.util.JwtProvider
+import com.coinbattle.domain.battle.repository.BattleSessionRepository
+import com.coinbattle.domain.user.entity.AuthProvider
+import com.coinbattle.domain.user.entity.User
+import com.coinbattle.domain.user.repository.UserRepository
+import com.coinbattle.domain.user.service.UserService
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.Optional
+
+@ExtendWith(MockKExtension::class)
+class UserServiceTest {
+
+    @MockK
+    lateinit var userRepository: UserRepository
+
+    @MockK
+    lateinit var battleSessionRepository: BattleSessionRepository
+
+    @MockK
+    lateinit var jwtProvider: JwtProvider
+
+    lateinit var userService: UserService
+
+    @BeforeEach
+    fun setUp() {
+        userService = UserService(userRepository, battleSessionRepository, jwtProvider)
+    }
+
+    @Test
+    fun `updateNickname_자신의_닉네임과_동일하면_성공`() {
+        val user = createUser(1L, "sameNick")
+        every { userRepository.findById(1L) } returns Optional.of(user)
+
+        val result = userService.updateNickname(1L, "sameNick")
+
+        assertThat(result.nickname).isEqualTo("sameNick")
+    }
+
+    @Test
+    fun `updateNickname_중복_닉네임이면_예외`() {
+        val user = createUser(1L, "oldNick")
+        every { userRepository.findById(1L) } returns Optional.of(user)
+        every { userRepository.existsByNickname("dupNick") } returns true
+
+        assertThatThrownBy { userService.updateNickname(1L, "dupNick") }
+            .isInstanceOf(CoinBattleException::class.java)
+            .hasMessageContaining(ErrorCode.DUPLICATE_NICKNAME.message)
+    }
+
+    @Test
+    fun `updateNickname_정상_변경`() {
+        val user = createUser(1L, "oldNick")
+        every { userRepository.findById(1L) } returns Optional.of(user)
+        every { userRepository.existsByNickname("newNick") } returns false
+
+        val result = userService.updateNickname(1L, "newNick")
+
+        assertThat(result.nickname).isEqualTo("newNick")
+        assertThat(result.userId).isEqualTo(1L)
+    }
+
+    @Test
+    fun `getUserStats_배틀_없을때_winRate_null`() {
+        every { battleSessionRepository.countWins(1L) } returns 0L
+        every { battleSessionRepository.countLosses(1L) } returns 0L
+        every { battleSessionRepository.countDraws(1L) } returns 0L
+        every { battleSessionRepository.findBestReturnRate(1L) } returns null
+
+        val result = userService.getUserStats(1L)
+
+        assertThat(result.wins).isEqualTo(0)
+        assertThat(result.totalGames).isEqualTo(0)
+        assertThat(result.winRate).isNull()
+        assertThat(result.bestReturnRate).isNull()
+    }
+
+    @Test
+    fun `getUserStats_정상_승률_계산`() {
+        every { battleSessionRepository.countWins(1L) } returns 3L
+        every { battleSessionRepository.countLosses(1L) } returns 1L
+        every { battleSessionRepository.countDraws(1L) } returns 0L
+        every { battleSessionRepository.findBestReturnRate(1L) } returns 42.5
+
+        val result = userService.getUserStats(1L)
+
+        assertThat(result.wins).isEqualTo(3)
+        assertThat(result.losses).isEqualTo(1)
+        assertThat(result.totalGames).isEqualTo(4)
+        assertThat(result.winRate).isEqualTo(75.0)
+        assertThat(result.bestReturnRate).isEqualTo(42.5)
+    }
+
+    private fun createUser(id: Long, nickname: String): User {
+        val user = User(
+            email = "user$id@test.com",
+            nickname = nickname,
+            provider = AuthProvider.KAKAO,
+            providerId = "provider_$id"
+        )
+        val field = User::class.java.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(user, id)
+        return user
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { BattlePage } from './pages/BattlePage';
 import { BattleRoom } from './pages/BattleRoom';
 import { PortfolioPage } from './pages/PortfolioPage';
 import { BattleResultPage } from './pages/BattleResultPage';
+import { ProfilePage } from './pages/ProfilePage';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
       <Route path="/ranking" element={<AuthGuard><RankingPage /></AuthGuard>} />
       <Route path="/result/:battleId" element={<AuthGuard><BattleResultPage /></AuthGuard>} />
       <Route path="/portfolio" element={<AuthGuard><PortfolioPage /></AuthGuard>} />
+      <Route path="/profile" element={<AuthGuard><ProfilePage /></AuthGuard>} />
     </Routes>
   );
 }

--- a/frontend/src/hooks/useUpdateProfile.ts
+++ b/frontend/src/hooks/useUpdateProfile.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { useAuthStore } from '../store/authStore';
+import type { ApiResponse, UserProfileResponse } from '../types';
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+  const setNickname = useAuthStore((s) => s.setNickname);
+
+  return useMutation({
+    mutationFn: async (nickname: string) => {
+      const res = await api.patch<ApiResponse<UserProfileResponse>>('/api/users/me', { nickname });
+      return res.data.data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['user', 'profile'], data);
+      setNickname(data.nickname);
+    },
+  });
+}

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { ApiResponse, UserProfileResponse } from '../types';
+
+export function useUserProfile() {
+  return useQuery({
+    queryKey: ['user', 'profile'],
+    queryFn: async () => {
+      const res = await api.get<ApiResponse<UserProfileResponse>>('/api/users/me');
+      return res.data.data;
+    },
+    staleTime: 60_000,
+    gcTime: 300_000,
+  });
+}

--- a/frontend/src/hooks/useUserStats.ts
+++ b/frontend/src/hooks/useUserStats.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { ApiResponse, UserStatsResponse } from '../types';
+
+export function useUserStats() {
+  return useQuery({
+    queryKey: ['user', 'stats'],
+    queryFn: async () => {
+      const res = await api.get<ApiResponse<UserStatsResponse>>('/api/users/me/stats');
+      return res.data.data;
+    },
+    staleTime: 30_000,
+    gcTime: 60_000,
+  });
+}

--- a/frontend/src/pages/MarketListPage.tsx
+++ b/frontend/src/pages/MarketListPage.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useNavigate } from 'react-router-dom';
+import { UserCircle } from 'lucide-react';
 import { useMarketTickers } from '../hooks/useMarketTickers';
 import { useTickerSubscription } from '../hooks/useTickerSubscription';
 import { useTickerStore, type Ticker } from '../store/tickerStore';
+import { useAuthStore } from '../store/authStore';
 
 type ExchangeFilter = 'ALL' | 'UPBIT' | 'BINANCE';
 
@@ -128,6 +130,8 @@ export function MarketListPage() {
   const [exchangeFilter, setExchangeFilter] = useState<ExchangeFilter>('ALL');
   const { isLoading, isError, refetch } = useMarketTickers();
   const tickers = useTickerStore((s) => s.tickers);
+  const nickname = useAuthStore((s) => s.nickname);
+  const navigate = useNavigate();
 
   const filtered = Array.from(tickers.values())
     .filter((t) => {
@@ -166,6 +170,19 @@ export function MarketListPage() {
           {!isLoading && sorted.length > 0 && (
             <span className="text-xs text-zinc-600 ml-auto">{sorted.length}개</span>
           )}
+          <button
+            onClick={() => navigate('/profile')}
+            className="ml-2 flex items-center justify-center w-8 h-8 rounded-full bg-zinc-800 hover:bg-zinc-700 transition-colors shrink-0"
+            aria-label="프로필"
+          >
+            {nickname ? (
+              <span className="text-xs font-bold text-orange-400">
+                {nickname.charAt(0).toUpperCase()}
+              </span>
+            ) : (
+              <UserCircle size={18} className="text-zinc-400" />
+            )}
+          </button>
         </div>
       </header>
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,285 @@
+const COLORS = {
+  background: '#0C0C0D',
+  cardBg: '#18181B',
+  cardBorder: '#27272A',
+  accent: '#FF6B35',
+  profit: '#2DD4BF',
+  loss: '#f87171',
+} as const;
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'motion/react';
+import { ChevronLeft, Pencil, Check, X, Trophy, Swords, Minus } from 'lucide-react';
+import { useUserProfile } from '../hooks/useUserProfile';
+import { useUserStats } from '../hooks/useUserStats';
+import { useUpdateProfile } from '../hooks/useUpdateProfile';
+import type { AxiosError } from 'axios';
+
+function SkeletonCard({ height = 80 }: { height?: number }) {
+  return (
+    <div
+      className="rounded-2xl p-4 border animate-pulse"
+      style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder, minHeight: height }}
+    >
+      <div className="w-20 h-4 bg-zinc-800 rounded mb-3" />
+      <div className="w-28 h-6 bg-zinc-800 rounded" />
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+  icon,
+}: {
+  label: string;
+  value: number;
+  color: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="flex-1 rounded-2xl p-4 border flex flex-col items-center gap-1"
+      style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+    >
+      <div style={{ color }}>{icon}</div>
+      <p className="text-2xl font-bold" style={{ color }}>
+        {value}
+      </p>
+      <p className="text-xs text-zinc-500">{label}</p>
+    </motion.div>
+  );
+}
+
+export function ProfilePage() {
+  const navigate = useNavigate();
+  const { data: profile, isLoading: profileLoading } = useUserProfile();
+  const { data: stats, isLoading: statsLoading } = useUserStats();
+  const updateProfile = useUpdateProfile();
+
+  const [editing, setEditing] = useState(false);
+  const [nickInput, setNickInput] = useState('');
+  const [nickError, setNickError] = useState<string | null>(null);
+
+  function handleEditStart() {
+    setNickInput(profile?.nickname ?? '');
+    setNickError(null);
+    setEditing(true);
+  }
+
+  function handleEditCancel() {
+    setEditing(false);
+    setNickError(null);
+  }
+
+  async function handleEditSave() {
+    if (!nickInput.trim() || nickInput.length < 2 || nickInput.length > 20) {
+      setNickError('닉네임은 2~20자 사이여야 합니다');
+      return;
+    }
+    try {
+      await updateProfile.mutateAsync(nickInput.trim());
+      setEditing(false);
+      setNickError(null);
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ message: string }>;
+      setNickError(axiosErr.response?.data?.message ?? '닉네임 변경에 실패했습니다');
+    }
+  }
+
+  const initial = profile?.nickname?.charAt(0).toUpperCase() ?? '?';
+  const winRate = stats?.winRate ?? 0;
+
+  return (
+    <div className="min-h-screen pb-10" style={{ backgroundColor: COLORS.background, color: '#fff' }}>
+      <div
+        className="sticky top-0 z-10 flex items-center gap-3 px-4 py-3 border-b backdrop-blur-sm"
+        style={{ backgroundColor: COLORS.background + 'CC', borderColor: COLORS.cardBorder }}
+      >
+        <button
+          onClick={() => navigate(-1)}
+          className="p-1 rounded-lg hover:bg-zinc-800 transition-colors"
+        >
+          <ChevronLeft size={22} />
+        </button>
+        <h1 className="text-base font-bold">내 프로필</h1>
+      </div>
+
+      <div className="px-4 mt-6 space-y-4">
+        {profileLoading ? (
+          <SkeletonCard height={120} />
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            className="rounded-2xl p-5 border"
+            style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="w-14 h-14 rounded-full flex items-center justify-center text-xl font-bold shrink-0"
+                style={{ backgroundColor: COLORS.accent + '22', color: COLORS.accent }}
+              >
+                {profile?.profileImageUrl ? (
+                  <img
+                    src={profile.profileImageUrl}
+                    alt="profile"
+                    className="w-full h-full rounded-full object-cover"
+                  />
+                ) : (
+                  initial
+                )}
+              </div>
+
+              <div className="flex-1 min-w-0">
+                {editing ? (
+                  <div className="space-y-2">
+                    <input
+                      value={nickInput}
+                      onChange={(e) => setNickInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleEditSave();
+                        if (e.key === 'Escape') handleEditCancel();
+                      }}
+                      autoFocus
+                      maxLength={20}
+                      className="w-full bg-zinc-800 text-white text-sm rounded-lg px-3 py-2 outline-none border border-zinc-600 focus:border-zinc-400"
+                      placeholder="닉네임 입력"
+                    />
+                    {nickError && (
+                      <p className="text-xs" style={{ color: COLORS.loss }}>
+                        {nickError}
+                      </p>
+                    )}
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleEditSave}
+                        disabled={updateProfile.isPending}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-lg font-medium transition-colors"
+                        style={{ backgroundColor: COLORS.accent, color: '#fff' }}
+                      >
+                        <Check size={12} />
+                        저장
+                      </button>
+                      <button
+                        onClick={handleEditCancel}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-lg font-medium bg-zinc-700 hover:bg-zinc-600 transition-colors"
+                      >
+                        <X size={12} />
+                        취소
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <p className="font-bold text-base truncate">{profile?.nickname}</p>
+                    <button
+                      onClick={handleEditStart}
+                      className="p-1 rounded-md hover:bg-zinc-700 transition-colors shrink-0"
+                    >
+                      <Pencil size={14} className="text-zinc-400" />
+                    </button>
+                  </div>
+                )}
+                <p className="text-xs text-zinc-500 mt-1 truncate">{profile?.email}</p>
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        <p className="text-xs font-semibold tracking-widest uppercase text-zinc-500 pt-2">
+          PVP 전적
+        </p>
+
+        {statsLoading ? (
+          <div className="flex gap-3">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        ) : (
+          <div className="flex gap-3">
+            <StatCard
+              label="승"
+              value={stats?.wins ?? 0}
+              color={COLORS.profit}
+              icon={<Trophy size={18} />}
+            />
+            <StatCard
+              label="패"
+              value={stats?.losses ?? 0}
+              color={COLORS.loss}
+              icon={<Swords size={18} />}
+            />
+            <StatCard
+              label="무"
+              value={stats?.draws ?? 0}
+              color="#94a3b8"
+              icon={<Minus size={18} />}
+            />
+          </div>
+        )}
+
+        {!statsLoading && (stats?.totalGames ?? 0) > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="rounded-2xl p-4 border"
+            style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+          >
+            <div className="flex justify-between mb-2">
+              <p className="text-xs text-zinc-500">승률</p>
+              <p className="text-xs font-bold" style={{ color: COLORS.profit }}>
+                {winRate.toFixed(1)}%
+              </p>
+            </div>
+            <div className="w-full h-2 rounded-full bg-zinc-800 overflow-hidden">
+              <motion.div
+                initial={{ width: 0 }}
+                animate={{ width: `${Math.min(winRate, 100)}%` }}
+                transition={{ duration: 0.6, ease: 'easeOut' }}
+                className="h-full rounded-full"
+                style={{ backgroundColor: COLORS.profit }}
+              />
+            </div>
+          </motion.div>
+        )}
+
+        <p className="text-xs font-semibold tracking-widest uppercase text-zinc-500 pt-2">
+          시즌 기록
+        </p>
+
+        {statsLoading ? (
+          <SkeletonCard />
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.15 }}
+            className="rounded-2xl p-4 border"
+            style={{ backgroundColor: COLORS.cardBg, borderColor: COLORS.cardBorder }}
+          >
+            <p className="text-xs text-zinc-500 mb-1">시즌 최고 수익률</p>
+            {stats?.bestReturnRate != null ? (
+              <p
+                className="text-2xl font-bold"
+                style={{ color: stats.bestReturnRate >= 0 ? COLORS.profit : COLORS.loss }}
+              >
+                {stats.bestReturnRate >= 0 ? '+' : ''}
+                {stats.bestReturnRate.toFixed(2)}%
+              </p>
+            ) : (
+              <p className="text-sm text-zinc-600">기록 없음</p>
+            )}
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -3,7 +3,9 @@ import { create } from 'zustand';
 interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
+  nickname: string | null;
   setTokens: (accessToken: string, refreshToken: string) => void;
+  setNickname: (nickname: string) => void;
   clearAuth: () => void;
   isAuthenticated: () => boolean;
 }
@@ -11,15 +13,21 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set, get) => ({
   accessToken: localStorage.getItem('accessToken'),
   refreshToken: localStorage.getItem('refreshToken'),
+  nickname: localStorage.getItem('nickname'),
   setTokens: (accessToken, refreshToken) => {
     localStorage.setItem('accessToken', accessToken);
     localStorage.setItem('refreshToken', refreshToken);
     set({ accessToken, refreshToken });
   },
+  setNickname: (nickname) => {
+    localStorage.setItem('nickname', nickname);
+    set({ nickname });
+  },
   clearAuth: () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
-    set({ accessToken: null, refreshToken: null });
+    localStorage.removeItem('nickname');
+    set({ accessToken: null, refreshToken: null, nickname: null });
   },
   isAuthenticated: () => !!get().accessToken,
 }));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -27,9 +27,19 @@ export interface Portfolio {
   totalPnlRate: number;
 }
 
+export interface RecentOrder {
+  orderId: number;
+  ticker: string;
+  side: 'BUY' | 'SELL';
+  executedPrice: number;
+  amount: number;
+  createdAt: string;
+}
+
 export interface PortfolioResponse {
   portfolio: Portfolio;
   positions: Position[];
+  recentOrders: RecentOrder[];
 }
 
 export interface BuyOrderRequest {
@@ -247,4 +257,20 @@ export interface BattleResultResponse {
   endedAt: string | null;
   participants: ParticipantResultResponse[];
   myResult: ParticipantResultResponse | null;
+}
+
+export interface UserProfileResponse {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+  email: string;
+}
+
+export interface UserStatsResponse {
+  wins: number;
+  losses: number;
+  draws: number;
+  totalGames: number;
+  winRate: number | null;
+  bestReturnRate: number | null;
 }


### PR DESCRIPTION
## 개요

사용자 프로필 조회/수정 API와 프론트엔드 프로필 페이지를 추가합니다. 닉네임 변경, PVP 전적(승/패/승률), 시즌 랭킹을 확인할 수 있습니다.

## 변경 내용

- `UserController.kt` 신규 생성 — `GET /api/users/me`, `PATCH /api/users/me`, `GET /api/users/me/stats`
- `UserService.kt` 닉네임 변경·중복 체크 및 PVP 전적 집계 메서드 추가
- `UpdateProfileRequest`, `UserProfileResponse`, `UserStatsResponse` DTO 추가
- `ProfilePage.tsx` 생성 — 닉네임 수정 폼, PVP 전적, 시즌 최고 수익률 표시
- `App.tsx` `/profile` 라우트 추가 및 네비게이션 링크 연결
- `useUserProfile`, `useUserStats`, `useUpdateProfile` 훅 추가

## 관련 이슈

Close #30