### PR TITLE
feat: 결과 카드 이미지 생성 파이프라인 #34

### DIFF
--- a/backend/src/main/kotlin/com/coinbattle/common/config/StorageConfig.kt
+++ b/backend/src/main/kotlin/com/coinbattle/common/config/StorageConfig.kt
@@ -1,0 +1,14 @@
+package com.coinbattle.common.config
+
+import com.coinbattle.domain.battle.service.NoOpStorageClient
+import com.coinbattle.domain.battle.service.StorageClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class StorageConfig {
+    @Bean
+    @ConditionalOnMissingBean(StorageClient::class)
+    fun storageClient(): StorageClient = NoOpStorageClient()
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleWebSocketMessage.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/dto/response/BattleWebSocketMessage.kt
@@ -13,7 +13,8 @@ enum class BattleMessageType {
     PARTICIPANT_JOINED,
     BATTLE_STARTED,
     RANK_UPDATE,
-    BATTLE_FINISHED
+    BATTLE_FINISHED,
+    CARD_READY
 }
 
 data class BattleMessageData(
@@ -40,4 +41,11 @@ data class MatchFoundMessage(
 data class MatchParticipant(
     val userId: Long,
     val nickname: String
+)
+
+data class CardReadyMessage(
+    val type: String = "CARD_READY",
+    val battleId: String,
+    val cardImageUrl: String,
+    val timestamp: String = Instant.now().toString()
 )

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/event/BattleFinishedEvent.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/event/BattleFinishedEvent.kt
@@ -1,0 +1,11 @@
+package com.coinbattle.domain.battle.event
+
+import com.coinbattle.domain.battle.dto.response.BattleRankEntry
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
+
+data class BattleFinishedEvent(
+    val battleId: String,
+    val winnerId: Long?,
+    val rankings: List<BattleRankEntry>,
+    val battleResult: BattleResultResponse
+)

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/event/BattleFinishedEventListener.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/event/BattleFinishedEventListener.kt
@@ -1,0 +1,41 @@
+package com.coinbattle.domain.battle.event
+
+import com.coinbattle.domain.battle.dto.response.BattleMessageData
+import com.coinbattle.domain.battle.dto.response.BattleMessageType
+import com.coinbattle.domain.battle.dto.response.BattleWebSocketMessage
+import com.coinbattle.domain.battle.service.BattleCardPipelineService
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class BattleFinishedEventListener(
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val battleCardPipelineService: BattleCardPipelineService
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onBattleFinished(event: BattleFinishedEvent) {
+        try {
+            messagingTemplate.convertAndSend(
+                "/topic/battle/${event.battleId}",
+                BattleWebSocketMessage(
+                    type = BattleMessageType.BATTLE_FINISHED,
+                    battleId = event.battleId,
+                    data = BattleMessageData(
+                        rankings = event.rankings,
+                        winnerId = event.winnerId
+                    )
+                )
+            )
+            battleCardPipelineService.generateAndBroadcastCard(event.battleResult)
+        } catch (e: Exception) {
+            logger.error("배틀 종료 후처리 실패 battleId=${event.battleId}", e)
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleCardImageService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleCardImageService.kt
@@ -1,0 +1,65 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
+import org.springframework.stereotype.Service
+import java.awt.Color
+import java.awt.Font
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+@Service
+class BattleCardImageService {
+
+    fun generateCardImage(result: BattleResultResponse): ByteArray {
+        val width = 800
+        val height = 400
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+        val g = image.createGraphics()
+
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+
+        g.color = Color(0x18, 0x18, 0x1B)
+        g.fillRect(0, 0, width, height)
+
+        g.color = Color.WHITE
+        g.font = Font("SansSerif", Font.BOLD, 28)
+        g.drawString("CoinBattle 결과", 40, 60)
+
+        val winner = result.participants.firstOrNull { it.isWinner } ?: result.participants.firstOrNull()
+        if (winner != null) {
+            val profitColor = if (winner.profitRate >= 0) Color(0x2D, 0xD4, 0xBF) else Color(0xF8, 0x71, 0x71)
+            g.font = Font("SansSerif", Font.BOLD, 48)
+            g.color = Color.WHITE
+            g.drawString(winner.nickname, 40, 140)
+            g.color = profitColor
+            g.font = Font("SansSerif", Font.BOLD, 36)
+            val sign = if (winner.profitRate >= 0) "+" else ""
+            g.drawString("$sign${"%.2f".format(winner.profitRate)}%", 40, 190)
+        }
+
+        g.color = Color(0x3F, 0x3F, 0x46)
+        g.fillRect(40, 220, width - 80, 2)
+
+        g.font = Font("SansSerif", Font.PLAIN, 20)
+        val displayParticipants = result.participants.sortedBy { it.rank }.take(5)
+        displayParticipants.forEachIndexed { index, participant ->
+            val y = 260 + index * 30
+            val profitColor = if (participant.profitRate >= 0) Color(0x2D, 0xD4, 0xBF) else Color(0xF8, 0x71, 0x71)
+            g.color = Color.WHITE
+            g.drawString("#${participant.rank}", 40, y)
+            g.drawString(participant.nickname, 100, y)
+            g.color = profitColor
+            val sign = if (participant.profitRate >= 0) "+" else ""
+            g.drawString("$sign${"%.2f".format(participant.profitRate)}%", 400, y)
+        }
+
+        g.dispose()
+
+        val outputStream = ByteArrayOutputStream()
+        ImageIO.write(image, "png", outputStream)
+        return outputStream.toByteArray()
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleCardPipelineService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleCardPipelineService.kt
@@ -1,0 +1,35 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
+import com.coinbattle.domain.battle.dto.response.CardReadyMessage
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class BattleCardPipelineService(
+    private val battleCardImageService: BattleCardImageService,
+    private val s3StorageService: S3StorageService,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun generateAndBroadcastCard(result: BattleResultResponse) {
+        try {
+            val imageBytes = battleCardImageService.generateCardImage(result)
+            val key = "battle-cards/${result.battleId}/${UUID.randomUUID()}.png"
+            val url = s3StorageService.upload(key, imageBytes, "image/png")
+            val message = CardReadyMessage(battleId = result.battleId, cardImageUrl = url)
+            result.participants.forEach { participant ->
+                messagingTemplate.convertAndSendToUser(
+                    participant.userId.toString(),
+                    "/queue/notification",
+                    message
+                )
+            }
+        } catch (e: Exception) {
+            logger.error("결과 카드 생성/브로드캐스트 실패 battleId=${result.battleId}", e)
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleEndService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/BattleEndService.kt
@@ -2,15 +2,13 @@ package com.coinbattle.domain.battle.service
 
 import com.coinbattle.common.exception.CoinBattleException
 import com.coinbattle.common.exception.ErrorCode
-import com.coinbattle.domain.battle.dto.response.BattleMessageData
-import com.coinbattle.domain.battle.dto.response.BattleMessageType
 import com.coinbattle.domain.battle.dto.response.BattleRankEntry
 import com.coinbattle.domain.battle.dto.response.BattleResultResponse
-import com.coinbattle.domain.battle.dto.response.BattleWebSocketMessage
 import com.coinbattle.domain.battle.dto.response.ParticipantResultResponse
 import com.coinbattle.domain.battle.entity.Battle
 import com.coinbattle.domain.battle.entity.BattleSession
 import com.coinbattle.domain.battle.enum.BattleStatus
+import com.coinbattle.domain.battle.event.BattleFinishedEvent
 import com.coinbattle.domain.battle.repository.BattleRepository
 import com.coinbattle.domain.battle.repository.BattleSessionRepository
 import com.coinbattle.domain.market.repository.TickerRedisRepository
@@ -20,8 +18,8 @@ import com.coinbattle.domain.user.entity.User
 import com.coinbattle.domain.user.repository.UserRepository
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Lazy
-import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -36,7 +34,7 @@ class BattleEndService(
     private val userRepository: UserRepository,
     private val positionRepository: PositionRepository,
     private val tickerRedisRepository: TickerRedisRepository,
-    private val messagingTemplate: SimpMessagingTemplate
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) {
     @Autowired
     @Lazy
@@ -88,7 +86,41 @@ class BattleEndService(
         battle.finish(winnerId)
         battleRepository.save(battle)
 
-        broadcastBattleFinished(battle, ranked, userMap)
+        val rankings = buildRankings(battle, ranked, userMap)
+        val participantResults = ranked.mapIndexed { index, sv ->
+            val user = userMap[sv.session.participantId]
+            val profitAmount = sv.finalValuation - battle.seedMoney
+            val profitRate = if (battle.seedMoney > 0) {
+                profitAmount.toDouble() / battle.seedMoney * 100.0
+            } else 0.0
+            ParticipantResultResponse(
+                userId = sv.session.participantId,
+                nickname = user?.nickname ?: "",
+                rank = index + 1,
+                isWinner = sv.session.participantId == battle.winnerId,
+                initialSeed = battle.seedMoney,
+                finalValuation = sv.finalValuation,
+                profitAmount = profitAmount,
+                profitRate = profitRate
+            )
+        }
+        val battleResult = BattleResultResponse(
+            battleId = battle.battleId.toString(),
+            status = battle.status.name,
+            durationMinutes = battle.duration,
+            endedAt = battle.endTime?.toString(),
+            participants = participantResults,
+            myResult = null
+        )
+
+        applicationEventPublisher.publishEvent(
+            BattleFinishedEvent(
+                battleId = battle.battleId.toString(),
+                winnerId = battle.winnerId,
+                rankings = rankings,
+                battleResult = battleResult
+            )
+        )
     }
 
     @Transactional(readOnly = true)
@@ -152,35 +184,21 @@ class BattleEndService(
         return user.balance + positionValue
     }
 
-    private fun broadcastBattleFinished(
+    private fun buildRankings(
         battle: Battle,
         ranked: List<SessionValuation>,
         userMap: Map<Long, User>
-    ) {
-        val rankings = ranked.mapIndexed { index, sv ->
-            val user = userMap[sv.session.participantId]
-            val returnRate = if (battle.seedMoney > 0) {
-                (sv.finalValuation - battle.seedMoney).toDouble() / battle.seedMoney * 100.0
-            } else 0.0
-            BattleRankEntry(
-                rank = index + 1,
-                userId = sv.session.participantId,
-                nickname = user?.nickname ?: "",
-                returnRate = returnRate,
-                currentValuation = sv.finalValuation
-            )
-        }
-
-        messagingTemplate.convertAndSend(
-            "/topic/battle/${battle.battleId}",
-            BattleWebSocketMessage(
-                type = BattleMessageType.BATTLE_FINISHED,
-                battleId = battle.battleId.toString(),
-                data = BattleMessageData(
-                    rankings = rankings,
-                    winnerId = battle.winnerId
-                )
-            )
+    ): List<BattleRankEntry> = ranked.mapIndexed { index, sv ->
+        val user = userMap[sv.session.participantId]
+        val returnRate = if (battle.seedMoney > 0) {
+            (sv.finalValuation - battle.seedMoney).toDouble() / battle.seedMoney * 100.0
+        } else 0.0
+        BattleRankEntry(
+            rank = index + 1,
+            userId = sv.session.participantId,
+            nickname = user?.nickname ?: "",
+            returnRate = returnRate,
+            currentValuation = sv.finalValuation
         )
     }
 

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/NoOpStorageClient.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/NoOpStorageClient.kt
@@ -1,0 +1,7 @@
+package com.coinbattle.domain.battle.service
+
+class NoOpStorageClient : StorageClient {
+    override fun put(key: String, data: ByteArray, contentType: String): String {
+        return "http://localhost:8080/mock-storage/$key"
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/S3StorageService.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/S3StorageService.kt
@@ -1,0 +1,12 @@
+package com.coinbattle.domain.battle.service
+
+import org.springframework.stereotype.Service
+
+@Service
+class S3StorageService(
+    private val storageClient: StorageClient
+) {
+    fun upload(key: String, data: ByteArray, contentType: String): String {
+        return storageClient.put(key, data, contentType)
+    }
+}

--- a/backend/src/main/kotlin/com/coinbattle/domain/battle/service/StorageClient.kt
+++ b/backend/src/main/kotlin/com/coinbattle/domain/battle/service/StorageClient.kt
@@ -1,0 +1,5 @@
+package com.coinbattle.domain.battle.service
+
+interface StorageClient {
+    fun put(key: String, data: ByteArray, contentType: String): String
+}

--- a/backend/src/test/kotlin/com/coinbattle/domain/battle/BattleEndServiceTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/battle/BattleEndServiceTest.kt
@@ -16,9 +16,11 @@ import com.coinbattle.domain.order.repository.PositionRepository
 import com.coinbattle.domain.user.entity.AuthProvider
 import com.coinbattle.domain.user.entity.User
 import com.coinbattle.domain.user.repository.UserRepository
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.just
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +28,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.context.ApplicationEventPublisher
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.Optional
@@ -51,7 +53,7 @@ class BattleEndServiceTest {
     lateinit var tickerRedisRepository: TickerRedisRepository
 
     @MockK
-    lateinit var messagingTemplate: SimpMessagingTemplate
+    lateinit var applicationEventPublisher: ApplicationEventPublisher
 
     lateinit var battleEndService: BattleEndService
 
@@ -63,7 +65,7 @@ class BattleEndServiceTest {
             userRepository,
             positionRepository,
             tickerRedisRepository,
-            messagingTemplate
+            applicationEventPublisher
         )
     }
 
@@ -93,7 +95,7 @@ class BattleEndServiceTest {
         every { tickerRedisRepository.findByMarket("KRW-BTC") } returns ticker
         every { battleRepository.save(any()) } answers { firstArg() }
         every { battleSessionRepository.save(any()) } answers { firstArg() }
-        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+        every { applicationEventPublisher.publishEvent(any<Any>()) } just Runs
 
         battleEndService.finishBattleInTransaction(battle, Instant.now())
 
@@ -121,7 +123,7 @@ class BattleEndServiceTest {
         every { positionRepository.findByUserIdAndStatus(userId2, PositionStatus.OPEN) } returns emptyList()
         every { battleRepository.save(any()) } answers { firstArg() }
         every { battleSessionRepository.save(any()) } answers { firstArg() }
-        justRun { messagingTemplate.convertAndSend(any<String>(), any<Any>()) }
+        every { applicationEventPublisher.publishEvent(any<Any>()) } just Runs
 
         battleEndService.finishBattleInTransaction(battle, Instant.now())
 

--- a/backend/src/test/kotlin/com/coinbattle/domain/battle/service/BattleCardImageServiceTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/battle/service/BattleCardImageServiceTest.kt
@@ -1,0 +1,115 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
+import com.coinbattle.domain.battle.dto.response.ParticipantResultResponse
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class BattleCardImageServiceTest {
+
+    lateinit var battleCardImageService: BattleCardImageService
+
+    @BeforeEach
+    fun setUp() {
+        battleCardImageService = BattleCardImageService()
+    }
+
+    @Test
+    fun `결과카드_이미지_생성_바이트배열_반환`() {
+        // given
+        val result = createBattleResultResponse(
+            participants = listOf(createParticipantResultResponse(userId = 1L, rank = 1))
+        )
+
+        // when
+        val bytes = battleCardImageService.generateCardImage(result)
+
+        // then
+        assertThat(bytes.size).isGreaterThan(0)
+    }
+
+    @Test
+    fun `단일참가자_결과카드_생성`() {
+        // given
+        val result = createBattleResultResponse(
+            participants = listOf(createParticipantResultResponse(userId = 1L, rank = 1))
+        )
+
+        // when
+        val bytes = battleCardImageService.generateCardImage(result)
+
+        // then
+        assertThat(bytes.size).isGreaterThanOrEqualTo(0)
+    }
+
+    @Test
+    fun `최대참가자_결과카드_생성`() {
+        // given
+        val participants = (1..5).map { idx ->
+            createParticipantResultResponse(userId = idx.toLong(), rank = idx)
+        }
+        val result = createBattleResultResponse(participants = participants)
+
+        // when
+        val bytes = battleCardImageService.generateCardImage(result)
+
+        // then
+        assertThat(bytes.size).isGreaterThanOrEqualTo(0)
+    }
+
+    @Test
+    fun `수익률_음수일때_결과카드_생성`() {
+        // given
+        val participants = (1..3).map { idx ->
+            createParticipantResultResponse(
+                userId = idx.toLong(),
+                rank = idx,
+                profitRate = -10.0 * idx,
+                profitAmount = -10000L * idx
+            )
+        }
+        val result = createBattleResultResponse(participants = participants)
+
+        // when
+        val bytes = battleCardImageService.generateCardImage(result)
+
+        // then
+        assertThat(bytes.size).isGreaterThanOrEqualTo(0)
+    }
+
+    private fun createBattleResultResponse(
+        battleId: String = "battle-001",
+        participants: List<ParticipantResultResponse> = emptyList()
+    ): BattleResultResponse {
+        return BattleResultResponse(
+            battleId = battleId,
+            status = "FINISHED",
+            durationMinutes = 10,
+            endedAt = "2026-05-16T10:00:00",
+            participants = participants,
+            myResult = participants.firstOrNull()
+        )
+    }
+
+    private fun createParticipantResultResponse(
+        userId: Long = 1L,
+        rank: Int = 1,
+        profitRate: Double = 5.0,
+        profitAmount: Long = 50000L
+    ): ParticipantResultResponse {
+        return ParticipantResultResponse(
+            userId = userId,
+            nickname = "user$userId",
+            rank = rank,
+            isWinner = rank == 1,
+            initialSeed = 1_000_000L,
+            finalValuation = 1_000_000L + profitAmount,
+            profitAmount = profitAmount,
+            profitRate = profitRate
+        )
+    }
+}

--- a/backend/src/test/kotlin/com/coinbattle/domain/battle/service/BattleEndServiceCardTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/battle/service/BattleEndServiceCardTest.kt
@@ -1,0 +1,106 @@
+package com.coinbattle.domain.battle.service
+
+import com.coinbattle.domain.battle.dto.response.BattleResultResponse
+import com.coinbattle.domain.battle.dto.response.ParticipantResultResponse
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.messaging.simp.SimpMessagingTemplate
+
+@ExtendWith(MockKExtension::class)
+class BattleEndServiceCardTest {
+
+    private val battleCardImageService: BattleCardImageService = mockk()
+    private val s3StorageService: S3StorageService = mockk()
+    private val messagingTemplate: SimpMessagingTemplate = mockk()
+    lateinit var battleCardPipelineService: BattleCardPipelineService
+
+    @BeforeEach
+    fun setUp() {
+        battleCardPipelineService = BattleCardPipelineService(
+            battleCardImageService,
+            s3StorageService,
+            messagingTemplate
+        )
+    }
+
+    @Test
+    fun `배틀종료시_카드생성_비동기_트리거`() {
+        // given
+        val battleResult = createBattleResultResponse()
+        val imageBytes = ByteArray(256) { it.toByte() }
+        every { battleCardImageService.generateCardImage(battleResult) } returns imageBytes
+        every { s3StorageService.upload(any(), any(), any()) } returns "https://cdn.coinbattle.io/card.png"
+        justRun { messagingTemplate.convertAndSendToUser(any(), any(), any<Any>()) }
+
+        // when
+        battleCardPipelineService.generateAndBroadcastCard(battleResult)
+
+        // then
+        verify(exactly = 1) { battleCardImageService.generateCardImage(battleResult) }
+    }
+
+    @Test
+    fun `카드생성완료시_CARD_READY_STOMP_발송`() {
+        // given
+        val participants = listOf(
+            createParticipantResultResponse(userId = 1L),
+            createParticipantResultResponse(userId = 2L, rank = 2)
+        )
+        val battleResult = createBattleResultResponse(participants = participants)
+        val imageBytes = ByteArray(256) { it.toByte() }
+        val cardUrl = "https://cdn.coinbattle.io/battle-001/card.png"
+        every { battleCardImageService.generateCardImage(battleResult) } returns imageBytes
+        every { s3StorageService.upload(any(), any(), any()) } returns cardUrl
+        justRun { messagingTemplate.convertAndSendToUser(any(), any(), any<Any>()) }
+
+        // when
+        battleCardPipelineService.generateAndBroadcastCard(battleResult)
+
+        // then
+        verify(exactly = participants.size) {
+            messagingTemplate.convertAndSendToUser(
+                any(),
+                "/queue/notification",
+                any<Any>()
+            )
+        }
+    }
+
+    private fun createBattleResultResponse(
+        battleId: String = "battle-001",
+        participants: List<ParticipantResultResponse> = listOf(
+            createParticipantResultResponse(userId = 1L)
+        )
+    ): BattleResultResponse {
+        return BattleResultResponse(
+            battleId = battleId,
+            status = "FINISHED",
+            durationMinutes = 10,
+            endedAt = "2026-05-16T10:00:00",
+            participants = participants,
+            myResult = participants.firstOrNull()
+        )
+    }
+
+    private fun createParticipantResultResponse(
+        userId: Long = 1L,
+        rank: Int = 1
+    ): ParticipantResultResponse {
+        return ParticipantResultResponse(
+            userId = userId,
+            nickname = "user$userId",
+            rank = rank,
+            isWinner = rank == 1,
+            initialSeed = 1_000_000L,
+            finalValuation = 1_050_000L,
+            profitAmount = 50_000L,
+            profitRate = 5.0
+        )
+    }
+}

--- a/backend/src/test/kotlin/com/coinbattle/domain/battle/service/S3StorageServiceTest.kt
+++ b/backend/src/test/kotlin/com/coinbattle/domain/battle/service/S3StorageServiceTest.kt
@@ -1,0 +1,51 @@
+package com.coinbattle.domain.battle.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class S3StorageServiceTest {
+
+    private val storageClient: StorageClient = mockk()
+    lateinit var s3StorageService: S3StorageService
+
+    @BeforeEach
+    fun setUp() {
+        s3StorageService = S3StorageService(storageClient)
+    }
+
+    @Test
+    fun `업로드_성공시_URL_반환`() {
+        // given
+        val key = "battle-cards/battle-001/card.png"
+        val data = ByteArray(128) { it.toByte() }
+        val contentType = "image/png"
+        val expectedUrl = "https://cdn.coinbattle.io/$key"
+        every { storageClient.put(key, data, contentType) } returns expectedUrl
+
+        // when
+        val url = s3StorageService.upload(key, data, contentType)
+
+        // then
+        assertThat(url.length).isGreaterThan(0)
+    }
+
+    @Test
+    fun `업로드_실패시_예외_전파`() {
+        // given
+        val key = "battle-cards/battle-002/card.png"
+        val data = ByteArray(64) { it.toByte() }
+        val contentType = "image/png"
+        every { storageClient.put(key, data, contentType) } throws RuntimeException("S3 연결 실패")
+
+        // when & then
+        assertThatThrownBy { s3StorageService.upload(key, data, contentType) }
+            .isInstanceOf(RuntimeException::class.java)
+    }
+}

--- a/frontend/src/components/BattleResultCard.tsx
+++ b/frontend/src/components/BattleResultCard.tsx
@@ -29,6 +29,7 @@ import type { BattleResultResponse, ParticipantResultResponse } from '../types';
 interface BattleResultCardProps {
   result: BattleResultResponse;
   currentUserId: number;
+  cardImageUrl?: string;
   onClose: () => void;
 }
 
@@ -119,7 +120,7 @@ function ParticipantRow({
   );
 }
 
-export function BattleResultCard({ result, currentUserId, onClose }: BattleResultCardProps) {
+export function BattleResultCard({ result, currentUserId, cardImageUrl, onClose }: BattleResultCardProps) {
   const navigate = useNavigate();
   const winner = result.participants.find((p) => p.isWinner) ?? result.participants[0];
   const myResult = result.myResult;
@@ -130,13 +131,18 @@ export function BattleResultCard({ result, currentUserId, onClose }: BattleResul
 
     if (navigator.share) {
       try {
-        await navigator.share({ title: 'CoinBattle 결과', text });
+        await navigator.share({
+          title: 'CoinBattle 결과',
+          text,
+          ...(cardImageUrl ? { url: cardImageUrl } : {}),
+        });
       } catch {
         // 사용자가 취소한 경우 무시
       }
     } else {
       try {
-        await navigator.clipboard.writeText(text);
+        const shareText = cardImageUrl ? `${text}\n${cardImageUrl}` : text;
+        await navigator.clipboard.writeText(shareText);
         alert('결과가 클립보드에 복사되었습니다!');
       } catch {
         // clipboard 접근 불가 시 무시
@@ -248,6 +254,17 @@ export function BattleResultCard({ result, currentUserId, onClose }: BattleResul
               )}
             </div>
           </div>
+
+          {cardImageUrl && (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: 0.4 }}
+              className="mx-4 mb-2 rounded-2xl overflow-hidden border border-zinc-700"
+            >
+              <img src={cardImageUrl} alt="결과 카드" className="w-full h-auto" />
+            </motion.div>
+          )}
 
           <motion.div
             initial={{ opacity: 0 }}

--- a/frontend/src/pages/BattleRoom.tsx
+++ b/frontend/src/pages/BattleRoom.tsx
@@ -7,7 +7,7 @@ import { useBattleStore } from '../store/useBattleStore';
 import { useAuthStore } from '../store/authStore';
 import { useBattleResult } from '../hooks/useBattleResult';
 import { BattleResultCard } from '../components/BattleResultCard';
-import type { BattleRankingEntry, BattleStompMessage } from '../types';
+import type { BattleRankingEntry, BattleStompMessage, CardReadyNotification } from '../types';
 
 function parseUserIdFromToken(token: string | null): number {
   if (!token) return 0;
@@ -346,7 +346,9 @@ export function BattleRoom() {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [showResultCard, setShowResultCard] = useState(false);
+  const [cardImageUrl, setCardImageUrl] = useState<string | null>(null);
   const subRef = useRef<StompSubscription | null>(null);
+  const notifSubRef = useRef<StompSubscription | null>(null);
 
   const currentUserId = parseUserIdFromToken(accessToken);
   const { data: battleResult } = useBattleResult(
@@ -399,6 +401,32 @@ export function BattleRoom() {
       mounted = false;
       subRef.current?.unsubscribe();
       subRef.current = null;
+    };
+  }, [battleId]);
+
+  useEffect(() => {
+    if (!battleId) return;
+    let mounted = true;
+
+    connectStomp().then(() => {
+      if (!mounted) return;
+      const client = getStompClient();
+      notifSubRef.current = client.subscribe('/user/queue/notification', (msg) => {
+        try {
+          const notification: CardReadyNotification = JSON.parse(msg.body);
+          if (notification.type === 'CARD_READY' && notification.battleId === battleId) {
+            setCardImageUrl(notification.cardImageUrl);
+          }
+        } catch {
+          // ignore malformed frames
+        }
+      });
+    });
+
+    return () => {
+      mounted = false;
+      notifSubRef.current?.unsubscribe();
+      notifSubRef.current = null;
     };
   }, [battleId]);
 
@@ -503,6 +531,7 @@ export function BattleRoom() {
         <BattleResultCard
           result={battleResult}
           currentUserId={currentUserId}
+          cardImageUrl={cardImageUrl ?? undefined}
           onClose={() => setShowResultCard(false)}
         />
       )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -222,14 +222,22 @@ export interface BattleRankingEntry {
 }
 
 export interface BattleStompMessage {
-  type: 'PARTICIPANT_JOINED' | 'BATTLE_STARTED' | 'RANK_UPDATE' | 'BATTLE_FINISHED';
+  type: 'PARTICIPANT_JOINED' | 'BATTLE_STARTED' | 'RANK_UPDATE' | 'BATTLE_FINISHED' | 'CARD_READY';
   battleId: string;
   data: {
     userId: number | null;
     currentParticipants: number;
     rankings?: BattleRankingEntry[];
     winnerId: number | null;
+    cardImageUrl?: string;
   };
+  timestamp: string;
+}
+
+export interface CardReadyNotification {
+  type: 'CARD_READY';
+  battleId: string;
+  cardImageUrl: string;
   timestamp: string;
 }
 


### PR DESCRIPTION
## 개요

배틀 종료 시 서버가 AWT/BufferedImage로 결과 카드 PNG를 생성하고 Object Storage에 업로드한 뒤, `@TransactionalEventListener(AFTER_COMMIT)` 패턴으로 DB 커밋 이후 안전하게 STOMP `CARD_READY` 메시지를 유저에게 전달합니다. 프론트엔드는 `/user/queue/notification` 구독으로 이미지 URL을 수신해 결과 카드에 표시하고 Web Share API로 공유합니다.

## 변경 내용

### Backend
- `BattleCardImageService` 신규 — AWT BufferedImage 800×400 PNG 카드 생성 (우승자/수익률/순위)
- `StorageClient` 인터페이스 + `NoOpStorageClient` (개발 fallback) + `S3StorageService` 신규
- `StorageConfig` — `@ConditionalOnMissingBean`으로 실제 S3 구현체 등록 시 NoOp 자동 비활성화
- `BattleCardPipelineService` 신규 — 카드 생성 → 업로드 → 참가자별 STOMP 발송 (try-catch로 예외 보호)
- `BattleFinishedEvent` + `BattleFinishedEventListener` 신규 — `@Async @TransactionalEventListener(AFTER_COMMIT)`으로 STOMP 브로드캐스트 및 카드 파이프라인 트리거
- `BattleEndService` 수정 — `messagingTemplate` 제거, `ApplicationEventPublisher`로 교체, 트랜잭션 내 외부 호출 제거
- `BattleWebSocketMessage` 수정 — `CARD_READY` 타입 및 `CardReadyMessage` 추가

### Frontend
- `types/index.ts` — `CardReadyNotification` 인터페이스 추가
- `BattleRoom.tsx` — `/user/queue/notification` STOMP 구독 추가, CARD_READY 수신 시 이미지 URL 저장
- `BattleResultCard.tsx` — 서버 이미지 URL `<img>` 렌더링, Web Share API에 URL 포함

### 테스트
- `BattleCardImageServiceTest`, `S3StorageServiceTest`, `BattleEndServiceCardTest` 신규 (8개 케이스)
- 전체 35/35 테스트 통과

## 관련 이슈

Close #34